### PR TITLE
Clears all previous cache on reconnect and refresh

### DIFF
--- a/src/backend/z_scraper.py
+++ b/src/backend/z_scraper.py
@@ -744,6 +744,26 @@ class ZScraper:
     def reset_thread_pool(self):
         self.thread_pool = list(self.all_threads.values())
 
+    def reset_runtime_state(self):
+        """
+        Drop all per-thread caches and re-baseline CPU cycle counters.
+        Call this whenever the target has been reset or reconnected so that
+        stale watermark assumptions and cycle deltas do not leak across sessions.
+        """
+        self._m_scraper.watermark_cache.clear()
+
+        if not self.has_usage:
+            return
+
+        self.last_thread_cycles.clear()
+        self._m_scraper.begin_batch()
+        try:
+            self.init_cpu_cycles = self._m_scraper.read64(self._cpu_usage_address)[0]
+        finally:
+            self._m_scraper.end_batch()
+        self.last_cpu_cycles = self.init_cpu_cycles
+        self.last_cpu_delta = self.init_cpu_cycles
+
     def start_polling_thread(
         self,
         data_queue: queue.Queue,

--- a/src/frontend/tui/views/thread_list.py
+++ b/src/frontend/tui/views/thread_list.py
@@ -201,6 +201,7 @@ class ThreadListView(BaseStateView):
                 try:
                     self.controller.scraper.update_available_threads()
                     self.controller.scraper.reset_thread_pool()
+                    self.controller.scraper.reset_runtime_state()
                     self.controller.purge_queue()
                 except Exception as e:
                     self.controller.status_message = f"Error refreshing threads: {e}"

--- a/src/frontend/zview_tui.py
+++ b/src/frontend/zview_tui.py
@@ -123,6 +123,7 @@ class ZView:
         try:
             self.scraper.update_available_threads()
             self.scraper.reset_thread_pool()
+            self.scraper.reset_runtime_state()
             self.scraper.start_polling_thread(
                 self.data_queue, self.stop_event, self.scraper.inspection_period
             )


### PR DESCRIPTION
All data cached on watermarks and available threads is cleared after a reconnect method call, ensuring no leftover data corrupts the visualization after a fail.