### PR TITLE
Add session record and replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,38 @@ west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA
 ```
 
 
-## Arguments
+## Commands
 
-| Argument | Description |
-| --- | --- |
-| `-e, --elf-file` | Path to the firmware `.elf` file (e.g. `build/zephyr/zephyr.elf`). |
-| `-r, --runner` | Debug runner to use: `jlink`, `pyocd`, or `gdb`. |
-| `-t, --runner-target` | MCU descriptor for the chosen runner (see below). |
-| `--period` | Update period in seconds, can be a float. |
-| `--snapshot` | Record a live session to a `.ndjson.gz` file and exit (no TUI). Requires `--duration` or `--frames`. |
-| `--duration` | Snapshot upper bound, in seconds. |
-| `--frames` | Snapshot upper bound, in data frames. |
-| `--replay` | Replay a previously recorded `.ndjson.gz` file; skips live probe. `-r`/`-t` are not required. |
-| `--once` | Emit a single polling frame and exit (no TUI). |
-| `--json` | With `--once`, emit the frame as JSON on stdout. |
+ZView is invoked through one of four commands. Bare `zview ...` is a shortcut for `zview live ...`.
+
+| Command | Purpose | TUI |
+| --- | --- | --- |
+| `live` | Attach to a probe and render the TUI. Default when no command is given. | yes |
+| `record` | Capture a live session to a `.ndjson.gz` recording file and exit. | no |
+| `replay` | Render the TUI from a previously captured recording. | yes |
+| `dump` | Emit a single polling frame and exit. | no |
+
+### Common arguments
+
+| Argument | Used by | Description |
+| --- | --- | --- |
+| `-e, --elf-file` | all | Path to the firmware `.elf` file (e.g. `build/zephyr/zephyr.elf`). |
+| `-r, --runner` | `live`, `record`, `dump` | Debug runner: `jlink`, `pyocd`, or `gdb`. |
+| `-t, --runner-target` | `live`, `record`, `dump` | MCU descriptor for the chosen runner (see below). |
+| `--period` | `live`, `record`, `dump` | Polling period in seconds (default: `0.10`). |
+
+### Command-specific arguments
+
+| Argument | Command | Description |
+| --- | --- | --- |
+| `-o, --output` | `record` | Recording target path (`.ndjson.gz`). |
+| `--duration` | `record` | Recording upper bound, in seconds. |
+| `--frames` | `record` | Recording upper bound, in data frames. |
+| `--heap` | `record` | Capture per-frame fragmentation for the named `k_heap` variable. |
+| `-i, --input` | `replay`, `dump` | Recording source path (`.ndjson.gz`). |
+| `--no-pacing` | `replay` | Drain the recording as fast as possible instead of honoring its wall-clock cadence. |
+| `--frame` | `dump` | Which polling frame to emit (1-indexed; default: `1`). |
+| `--json` | `dump` | Emit the frame as JSON on stdout. |
 
 <details>
 <summary><strong>Finding the right value for <code>-t</code></strong></summary>
@@ -142,30 +160,39 @@ ZView can record a live session to disk, replay it later without a probe, or emi
 
 ```
 # 30 s of live polling from a JLink probe, saved to disk
-west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA \
-  --snapshot capture.ndjson.gz --duration 30
+west zview record -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA \
+  -o capture.ndjson.gz --duration 30
 ```
 
 Bound the recording by either `--duration` (seconds) or `--frames` (number of data frames).
+
+To also capture the **fragmentation map** for a specific heap, pass `--heap <name>` where `<name>` matches a `k_heap` variable from your firmware (e.g. `my_kernel_heap`):
+
+```
+west zview record -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA \
+  -o capture.ndjson.gz --duration 30 --heap my_kernel_heap
+```
 
 **Replay it later — no hardware needed:**
 
 ```
 # Feed the recording into the TUI
-west zview -e build/zephyr/zephyr.elf --replay capture.ndjson.gz
+west zview replay -e build/zephyr/zephyr.elf -i capture.ndjson.gz
 ```
+
+By default the replay honors the recording's original cadence. Pass `--no-pacing` to drain it as fast as possible.
 
 The ELF is still required: DWARF offsets are resolved at replay time and are not stored in the recording.
 
 **CI-friendly single-frame snapshot:**
 
 ```
-# One polling frame, dumped as JSON on stdout
-west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA --once --json \
+# One polling frame from a live probe, dumped as JSON on stdout
+west zview dump -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA --json \
   | jq '.threads[] | select(.runtime.stack_watermark_percent > 80)'
 ```
 
-Omit `--json` for a human-readable one-shot dump. `--once` also works with `--replay`, which is useful for deterministic regression tests.
+`dump` accepts either a live source (`-r`/`-t`) or a recording (`-i`). Omit `--json` for a human-readable one-shot dump. Use `--frame N` to emit the Nth polling frame instead of the first — useful when the first frame's CPU baseline hasn't settled.
 
 > **Note:** Status messages (probe connect, ELF load) are emitted on stderr, so stdout stays clean for piping into `jq` or similar.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA
 | `-r, --runner` | Debug runner to use: `jlink`, `pyocd`, or `gdb`. |
 | `-t, --runner-target` | MCU descriptor for the chosen runner (see below). |
 | `--period` | Update period in seconds, can be a float. |
+| `--snapshot` | Record a live session to a `.ndjson.gz` file and exit (no TUI). Requires `--duration` or `--frames`. |
+| `--duration` | Snapshot upper bound, in seconds. |
+| `--frames` | Snapshot upper bound, in data frames. |
+| `--replay` | Replay a previously recorded `.ndjson.gz` file; skips live probe. `-r`/`-t` are not required. |
+| `--once` | Emit a single polling frame and exit (no TUI). |
+| `--json` | With `--once`, emit the frame as JSON on stdout. |
 
 <details>
 <summary><strong>Finding the right value for <code>-t</code></strong></summary>
@@ -127,6 +133,42 @@ ZView acts as a TUI. Navigate with **UP** and **DOWN** arrows from the default v
 
 [![TUI heap fragmentation map](https://github.com/wkhadgar/zview/raw/main/docs/assets/heaps_detail_1.png)](https://github.com/wkhadgar/zview/blob/main/docs/assets/heaps_detail_1.png)
 
+
+## Offline workflows
+
+ZView can record a live session to disk, replay it later without a probe, or emit a single frame as JSON for CI.
+
+**Record a live session:**
+
+```
+# 30 s of live polling from a JLink probe, saved to disk
+west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA \
+  --snapshot capture.ndjson.gz --duration 30
+```
+
+Bound the recording by either `--duration` (seconds) or `--frames` (number of data frames).
+
+**Replay it later — no hardware needed:**
+
+```
+# Feed the recording into the TUI
+west zview -e build/zephyr/zephyr.elf --replay capture.ndjson.gz
+```
+
+The ELF is still required: DWARF offsets are resolved at replay time and are not stored in the recording.
+
+**CI-friendly single-frame snapshot:**
+
+```
+# One polling frame, dumped as JSON on stdout
+west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA --once --json \
+  | jq '.threads[] | select(.runtime.stack_watermark_percent > 80)'
+```
+
+Omit `--json` for a human-readable one-shot dump. `--once` also works with `--replay`, which is useful for deterministic regression tests.
+
+> **Note:** Status messages (probe connect, ELF load) are emitted on stderr, so stdout stays clean for piping into `jq` or similar.
+
 ---
 
 ## Advanced
@@ -172,12 +214,5 @@ ZView achieves a minimal footprint by avoiding on-target processing or UART/Shel
 > **Note:** The `idle` thread is implicit and only expresses itself on the used CPU %, when available.
 
 </details>
-
-
-## Roadmap
-
-Based on community feedback, the following features are in development:
-
-* Detailed thread metrics (e.g., context switch counts).
 
 Feel free to open an [issue](https://github.com/wkhadgar/zview/issues) if you feel like this has some potential!

--- a/README_pip.md
+++ b/README_pip.md
@@ -57,6 +57,12 @@ zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA
 | `-r, --runner` | Debug runner to use: `jlink`, `pyocd`, or `gdb`. |
 | `-t, --runner-target` | MCU descriptor for the chosen runner (see below). |
 | `--period` | Update period in seconds, can be a float. |
+| `--snapshot` | Record a live session to a `.ndjson.gz` file and exit (no TUI). Requires `--duration` or `--frames`. |
+| `--duration` | Snapshot upper bound, in seconds. |
+| `--frames` | Snapshot upper bound, in data frames. |
+| `--replay` | Replay a previously recorded `.ndjson.gz` file; skips live probe. `-r`/`-t` are not required. |
+| `--once` | Emit a single polling frame and exit (no TUI). |
+| `--json` | With `--once`, emit the frame as JSON on stdout. |
 
 <details>
 <summary><strong>Finding the right value for <code>-t</code></strong></summary>
@@ -90,4 +96,4 @@ zview -e build/zephyr/zephyr.elf -r gdb -t localhost:1234
 
 ---
 
-For navigation, advanced usage, and QEMU/GDB targets, refer to the [main documentation](https://github.com/wkhadgar/zview/blob/main/README.md).
+For navigation, offline recording/replay workflows, advanced usage, and QEMU/GDB targets, refer to the [main documentation](https://github.com/wkhadgar/zview/blob/main/README.md).

--- a/README_pip.md
+++ b/README_pip.md
@@ -49,20 +49,38 @@ zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA
 ```
 
 
-## Arguments
+## Commands
 
-| Argument | Description |
-| --- | --- |
-| `-e, --elf-file` | Path to the firmware `.elf` file (e.g. `build/zephyr/zephyr.elf`). |
-| `-r, --runner` | Debug runner to use: `jlink`, `pyocd`, or `gdb`. |
-| `-t, --runner-target` | MCU descriptor for the chosen runner (see below). |
-| `--period` | Update period in seconds, can be a float. |
-| `--snapshot` | Record a live session to a `.ndjson.gz` file and exit (no TUI). Requires `--duration` or `--frames`. |
-| `--duration` | Snapshot upper bound, in seconds. |
-| `--frames` | Snapshot upper bound, in data frames. |
-| `--replay` | Replay a previously recorded `.ndjson.gz` file; skips live probe. `-r`/`-t` are not required. |
-| `--once` | Emit a single polling frame and exit (no TUI). |
-| `--json` | With `--once`, emit the frame as JSON on stdout. |
+ZView is invoked through one of four commands. Bare `zview ...` is a shortcut for `zview live ...`.
+
+| Command | Purpose | TUI |
+| --- | --- | --- |
+| `live` | Attach to a probe and render the TUI. Default when no command is given. | yes |
+| `record` | Capture a live session to a `.ndjson.gz` recording file and exit. | no |
+| `replay` | Render the TUI from a previously captured recording. | yes |
+| `dump` | Emit a single polling frame and exit. | no |
+
+### Common arguments
+
+| Argument | Used by | Description |
+| --- | --- | --- |
+| `-e, --elf-file` | all | Path to the firmware `.elf` file. |
+| `-r, --runner` | `live`, `record`, `dump` | Debug runner: `jlink`, `pyocd`, or `gdb`. |
+| `-t, --runner-target` | `live`, `record`, `dump` | MCU descriptor for the chosen runner (see below). |
+| `--period` | `live`, `record`, `dump` | Polling period in seconds (default: `0.10`). |
+
+### Command-specific arguments
+
+| Argument | Command | Description |
+| --- | --- | --- |
+| `-o, --output` | `record` | Recording target path (`.ndjson.gz`). |
+| `--duration` | `record` | Recording upper bound, in seconds. |
+| `--frames` | `record` | Recording upper bound, in data frames. |
+| `--heap` | `record` | Capture per-frame fragmentation for the named `k_heap` variable. |
+| `-i, --input` | `replay`, `dump` | Recording source path (`.ndjson.gz`). |
+| `--no-pacing` | `replay` | Drain the recording as fast as possible instead of honoring its wall-clock cadence. |
+| `--frame` | `dump` | Which polling frame to emit (1-indexed; default: `1`). |
+| `--json` | `dump` | Emit the frame as JSON on stdout. |
 
 <details>
 <summary><strong>Finding the right value for <code>-t</code></strong></summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zview"
-version = "0.9.0"
+version = "0.10.0"
 authors = [{ name = "Paulo Santos", email = "pauloxrms@gmail.com" }]
 description = "ZView, a Zephyr RTOS runtime visualizer"
 dependencies = ["PyYAML", "pyelftools", "pyocd", "pylink-square"]

--- a/scripts/west_commands/zview_tui_cmd.py
+++ b/scripts/west_commands/zview_tui_cmd.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-from west import log
 from west.commands import WestCommand
 
 _zview_base = Path(__file__).parent.parent.parent
@@ -113,7 +112,7 @@ class ZViewCommand(WestCommand):
 
         elf_path = Path("build").resolve() / "zephyr" / "zephyr.elf"
         if not elf_path.exists():
-            log.die(
+            self.die(
                 f"Could not find firmware at '{elf_path}'. Please specify '-e' or run west build."
             )
         return _insert_after_command(argv, ["-e", str(elf_path)])
@@ -141,8 +140,10 @@ class ZViewCommand(WestCommand):
         try:
             runner_config = RunnerConfig(runners_yaml_path)
         except Exception as e:
-            log.err(e)
-            log.die("Failed to parse runners.yaml. Please specify runner ('-r') and target ('-t').")
+            self.err(e)
+            self.die(
+                "Failed to parse runners.yaml. Please specify runner ('-r') and target ('-t')."
+            )
 
         preferred = None
         for i, a in enumerate(argv):
@@ -156,11 +157,11 @@ class ZViewCommand(WestCommand):
         runner, target_mcu = runner_config.get_config(preferred_runner=preferred)
 
         if runner not in zview_cli.AVAILABLE_RUNNERS:
-            log.wrn(
+            self.wrn(
                 f"'{runner}' is not a valid runner for ZView. Try explicitly passing one of "
                 f"the following: {', '.join(zview_cli.AVAILABLE_RUNNERS)}"
             )
-            log.wrn("Trying to continue with PyOCD as runner...")
+            self.wrn("Trying to continue with PyOCD as runner...")
             runner, target_mcu = runner_config.get_config(preferred_runner="pyocd")
 
         injected: list[str] = []

--- a/scripts/west_commands/zview_tui_cmd.py
+++ b/scripts/west_commands/zview_tui_cmd.py
@@ -1,4 +1,3 @@
-import curses
 import sys
 from pathlib import Path
 
@@ -8,13 +7,41 @@ from west.commands import WestCommand
 _zview_base = Path(__file__).parent.parent.parent
 sys.path.append(str(_zview_base / "src"))
 
-from backend.gdb import GDBScraper
-from backend.jlink import JLinkScraper
-from backend.pyocd import PyOCDScraper
-from frontend.zview_tui import tui_run
-from logging_setup import configure as configure_logging
-from orchestrator import ZScraper
-from runner_config import RunnerConfig
+import zview_cli  # noqa: E402
+from logging_setup import configure as configure_logging  # noqa: E402
+from runner_config import RunnerConfig  # noqa: E402
+
+_COMMANDS_NEEDING_RUNNER = ("live", "record")
+
+
+def _has_flag(argv: list[str], short: str, long_: str) -> bool:
+    """True if ``short``, ``long_``, or ``long_=...`` appears in ``argv``."""
+    return any(a in (short, long_) or a.startswith(long_ + "=") for a in argv)
+
+
+def _help_requested(argv: list[str]) -> bool:
+    return any(a in ("-h", "--help") for a in argv)
+
+
+def _insert_after_command(argv: list[str], extras: list[str]) -> list[str]:
+    """
+    Insert ``extras`` immediately after the first known command in ``argv``,
+    or at the front when no command is present (which zview_cli will normalize
+    into the implicit ``live`` command). Keeps the user-visible verb at the
+    head of argv so downstream parsing isn't confused by injected flags.
+    """
+    for i, a in enumerate(argv):
+        if a in zview_cli.KNOWN_COMMANDS:
+            return [*argv[: i + 1], *extras, *argv[i + 1 :]]
+    return [*extras, *argv]
+
+
+def _command_wants_runner(cmd: str, argv: list[str]) -> bool:
+    if cmd in _COMMANDS_NEEDING_RUNNER:
+        return True
+    if cmd == "dump":
+        return not _has_flag(argv, "-i", "--input")
+    return False
 
 
 class ZViewCommand(WestCommand):
@@ -23,94 +50,122 @@ class ZViewCommand(WestCommand):
             'zview',
             'Zephyr RTOS system-wide runtime visualizer via SWD probe',
             'Take a broader look on your Zephyr application with a non-heavy, small footprint, '
-            'Kconfig-only thread stats analyser.',
+            'Kconfig-only thread stats analyser. '
+            'Run `west zview --help` for the full command list.',
+            # All arguments are forwarded to zview_cli; west must not reject them itself.
+            accepts_unknown_args=True,
         )
-
-        self.available_runners = ["gdb", "jlink", "pyocd"]
 
     def do_add_parser(self, parser_adder):
-        parser = parser_adder.add_parser(self.name, help=self.help, description=self.description)
-
-        parser.add_argument(
-            "-e", "--elf-file", help="Path to the application's .elf firmware file."
+        # Forward every argument to zview_cli unmodified; west auto-detection
+        # of ELF and runner happens in do_run before delegation.
+        parser = parser_adder.add_parser(
+            self.name,
+            help=self.help,
+            description=self.description,
+            add_help=False,
         )
-        parser.add_argument(
-            "-r",
-            "--runner",
-            choices=self.available_runners,
-            default=None,
-            help="Runner to start analysis with.",
-        )
-        parser.add_argument(
-            "-t",
-            "--runner-target",
-            default=None,
-            help="Descriptor name for the target MCU on the chosen runner",
-        )
-        parser.add_argument(
-            "--period",
-            default=0.10,
-            type=float,
-            help="Minimum period to update system information.",
-        )
-
         return parser
 
     def do_run(self, args, unknown):
-        del unknown
-
+        del args
         configure_logging()
 
-        build_path = Path('build').resolve()
+        argv = list(unknown)
+        argv = self._inject_elf_if_missing(argv)
+        argv = self._inject_runner_if_missing(argv)
 
-        if args.elf_file:
-            elf_path = Path(args.elf_file)
-        else:
-            elf_path = build_path / "zephyr" / "zephyr.elf"
+        elf_line = "  -e/--elf-file       from build/zephyr/zephyr.elf"
+        runner_line = "  -r/--runner         from build/zephyr/runners.yaml"
+        target_line = "  -t/--runner-target  from build/zephyr/runners.yaml"
 
-            if not elf_path.exists():
-                log.die(
-                    f"Could not find firmware at '{elf_path}'."
-                    " Please specify '-e' or run west build."
-                )
+        live_record_note = "Auto-detected when omitted:\n" + "\n".join(
+            (elf_line, runner_line, target_line)
+        )
+        replay_note = "Auto-detected when omitted:\n" + elf_line
+        dump_note = (
+            "Auto-detected when omitted:\n"
+            + elf_line
+            + "\n"
+            + runner_line
+            + " (when -i is not given)\n"
+            + target_line
+            + " (when -i is not given)"
+        )
 
-        runners_yaml_path = build_path / "zephyr" / "runners.yaml"
+        sys.exit(
+            zview_cli.main(
+                argv,
+                prog="west zview",
+                subcommand_epilogs={
+                    "live": live_record_note,
+                    "record": live_record_note,
+                    "replay": replay_note,
+                    "dump": dump_note,
+                },
+            )
+        )
 
-        runner = args.runner
-        target_mcu = args.runner_target
+    def _inject_elf_if_missing(self, argv: list[str]) -> list[str]:
+        """Prepend ``-e build/zephyr/zephyr.elf`` if no ELF flag is present."""
+        if _has_flag(argv, "-e", "--elf-file") or _help_requested(argv):
+            return argv
 
-        if runner and target_mcu:
-            pass
-        else:
-            try:
-                runner_config = RunnerConfig(runners_yaml_path)
-            except Exception as e:
-                log.err(e)
-                log.die(
-                    "Failed to parse runners.yaml. Please specify runner ('-r') and target ('-t')."
-                )
+        elf_path = Path("build").resolve() / "zephyr" / "zephyr.elf"
+        if not elf_path.exists():
+            log.die(
+                f"Could not find firmware at '{elf_path}'. Please specify '-e' or run west build."
+            )
+        return _insert_after_command(argv, ["-e", str(elf_path)])
 
-            runner, target_mcu = runner_config.get_config(preferred_runner=runner)
-            if runner not in self.available_runners:
-                log.wrn(
-                    f"'{runner}' is not a valid runner for ZView. Try explicitly passing one of "
-                    f"the following: {', '.join(self.available_runners)}"
-                )
-                log.wrn("Trying to continue with PyOCD as runner...")
-                runner, target_mcu = runner_config.get_config(preferred_runner="pyocd")
+    def _inject_runner_if_missing(self, argv: list[str]) -> list[str]:
+        """Fill ``-r``/``-t`` from build/zephyr/runners.yaml when the command needs them."""
+        if _help_requested(argv):
+            return argv
 
+        normalized = zview_cli._normalize_argv(argv)
+        if not normalized:
+            return argv
+        cmd = normalized[0]
+        if cmd not in zview_cli.KNOWN_COMMANDS:
+            return argv
+        if not _command_wants_runner(cmd, argv):
+            return argv
+
+        has_runner = _has_flag(argv, "-r", "--runner")
+        has_target = _has_flag(argv, "-t", "--runner-target")
+        if has_runner and has_target:
+            return argv
+
+        runners_yaml_path = Path("build").resolve() / "zephyr" / "runners.yaml"
         try:
-            scraper_map = {
-                "gdb": GDBScraper,
-                "jlink": JLinkScraper,
-                "pyocd": PyOCDScraper,
-            }
-
-            scraper_cls = scraper_map.get(runner, PyOCDScraper)
-
-            with scraper_cls(target_mcu) as meta_scraper:
-                z_scraper = ZScraper(meta_scraper, elf_path)
-                curses.wrapper(tui_run, z_scraper, args.period)
+            runner_config = RunnerConfig(runners_yaml_path)
         except Exception as e:
             log.err(e)
-            log.die("Error starting ZView, try 'west zview -h'")
+            log.die("Failed to parse runners.yaml. Please specify runner ('-r') and target ('-t').")
+
+        preferred = None
+        for i, a in enumerate(argv):
+            if a in ("-r", "--runner"):
+                preferred = argv[i + 1] if i + 1 < len(argv) else None
+                break
+            if a.startswith("--runner="):
+                preferred = a.split("=", 1)[1]
+                break
+
+        runner, target_mcu = runner_config.get_config(preferred_runner=preferred)
+
+        if runner not in zview_cli.AVAILABLE_RUNNERS:
+            log.wrn(
+                f"'{runner}' is not a valid runner for ZView. Try explicitly passing one of "
+                f"the following: {', '.join(zview_cli.AVAILABLE_RUNNERS)}"
+            )
+            log.wrn("Trying to continue with PyOCD as runner...")
+            runner, target_mcu = runner_config.get_config(preferred_runner="pyocd")
+
+        injected: list[str] = []
+        if not has_runner:
+            injected += ["-r", runner]
+        if not has_target and target_mcu:
+            injected += ["-t", str(target_mcu)]
+        return _insert_after_command(argv, injected)

--- a/scripts/west_commands/zview_tui_cmd.py
+++ b/scripts/west_commands/zview_tui_cmd.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 from pathlib import Path
 
@@ -13,34 +14,31 @@ from runner_config import RunnerConfig  # noqa: E402
 _COMMANDS_NEEDING_RUNNER = ("live", "record")
 
 
-def _has_flag(argv: list[str], short: str, long_: str) -> bool:
-    """True if ``short``, ``long_``, or ``long_=...`` appears in ``argv``."""
-    return any(a in (short, long_) or a.startswith(long_ + "=") for a in argv)
-
-
-def _help_requested(argv: list[str]) -> bool:
-    return any(a in ("-h", "--help") for a in argv)
-
-
-def _insert_after_command(argv: list[str], extras: list[str]) -> list[str]:
-    """
-    Insert ``extras`` immediately after the first known command in ``argv``,
-    or at the front when no command is present (which zview_cli will normalize
-    into the implicit ``live`` command). Keeps the user-visible verb at the
-    head of argv so downstream parsing isn't confused by injected flags.
-    """
-    for i, a in enumerate(argv):
-        if a in zview_cli.KNOWN_COMMANDS:
-            return [*argv[: i + 1], *extras, *argv[i + 1 :]]
-    return [*extras, *argv]
-
-
-def _command_wants_runner(cmd: str, argv: list[str]) -> bool:
-    if cmd in _COMMANDS_NEEDING_RUNNER:
+def _command_wants_runner(args: argparse.Namespace) -> bool:
+    if args.cmd in _COMMANDS_NEEDING_RUNNER:
         return True
-    if cmd == "dump":
-        return not _has_flag(argv, "-i", "--input")
+    if args.cmd == "dump":
+        return getattr(args, "input", None) is None
     return False
+
+
+def _build_subcommand_epilogs() -> dict[str, str]:
+    elf_line = "  -e/--elf-file       from build/zephyr/zephyr.elf"
+    runner_line = "  -r/--runner         from build/zephyr/runners.yaml"
+    target_line = "  -t/--runner-target  from build/zephyr/runners.yaml"
+
+    live_record = "Auto-detected when omitted:\n" + "\n".join((elf_line, runner_line, target_line))
+    replay = "Auto-detected when omitted:\n" + elf_line
+    dump = (
+        "Auto-detected when omitted:\n"
+        + elf_line
+        + "\n"
+        + runner_line
+        + " (when -i is not given)\n"
+        + target_line
+        + " (when -i is not given)"
+    )
+    return {"live": live_record, "record": live_record, "replay": replay, "dump": dump}
 
 
 class ZViewCommand(WestCommand):
@@ -51,110 +49,65 @@ class ZViewCommand(WestCommand):
             'Take a broader look on your Zephyr application with a non-heavy, small footprint, '
             'Kconfig-only thread stats analyser. '
             'Run `west zview --help` for the full command list.',
-            # All arguments are forwarded to zview_cli; west must not reject them itself.
-            accepts_unknown_args=True,
         )
 
     def do_add_parser(self, parser_adder):
-        # Forward every argument to zview_cli unmodified; west auto-detection
-        # of ELF and runner happens in do_run before delegation.
         parser = parser_adder.add_parser(
             self.name,
             help=self.help,
             description=self.description,
-            add_help=False,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        sub = parser.add_subparsers(dest="cmd", metavar="COMMAND")
+        zview_cli.register_commands(
+            sub,
+            auto_filled=frozenset({"elf", "target"}),
+            subcommand_epilogs=_build_subcommand_epilogs(),
+        )
+        parser.set_defaults(
+            cmd="live",
+            elf_file=None,
+            runner=None,
+            runner_target=None,
+            period=0.10,
         )
         return parser
 
     def do_run(self, args, unknown):
-        del args
+        del unknown
         configure_logging()
 
-        argv = list(unknown)
-        argv = self._inject_elf_if_missing(argv)
-        argv = self._inject_runner_if_missing(argv)
+        self._fill_elf(args)
+        if _command_wants_runner(args):
+            self._fill_runner(args)
 
-        elf_line = "  -e/--elf-file       from build/zephyr/zephyr.elf"
-        runner_line = "  -r/--runner         from build/zephyr/runners.yaml"
-        target_line = "  -t/--runner-target  from build/zephyr/runners.yaml"
+        zview_cli.validate_args(self.parser, args)
+        sys.exit(zview_cli.dispatch(args))
 
-        live_record_note = "Auto-detected when omitted:\n" + "\n".join(
-            (elf_line, runner_line, target_line)
-        )
-        replay_note = "Auto-detected when omitted:\n" + elf_line
-        dump_note = (
-            "Auto-detected when omitted:\n"
-            + elf_line
-            + "\n"
-            + runner_line
-            + " (when -i is not given)\n"
-            + target_line
-            + " (when -i is not given)"
-        )
-
-        sys.exit(
-            zview_cli.main(
-                argv,
-                prog="west zview",
-                subcommand_epilogs={
-                    "live": live_record_note,
-                    "record": live_record_note,
-                    "replay": replay_note,
-                    "dump": dump_note,
-                },
-            )
-        )
-
-    def _inject_elf_if_missing(self, argv: list[str]) -> list[str]:
-        """Prepend ``-e build/zephyr/zephyr.elf`` if no ELF flag is present."""
-        if _has_flag(argv, "-e", "--elf-file") or _help_requested(argv):
-            return argv
-
+    def _fill_elf(self, args: argparse.Namespace) -> None:
+        if args.elf_file is not None:
+            return
         elf_path = Path("build").resolve() / "zephyr" / "zephyr.elf"
         if not elf_path.exists():
             self.die(
                 f"Could not find firmware at '{elf_path}'. Please specify '-e' or run west build."
             )
-        return _insert_after_command(argv, ["-e", str(elf_path)])
+        args.elf_file = str(elf_path)
 
-    def _inject_runner_if_missing(self, argv: list[str]) -> list[str]:
-        """Fill ``-r``/``-t`` from build/zephyr/runners.yaml when the command needs them."""
-        if _help_requested(argv):
-            return argv
-
-        normalized = zview_cli._normalize_argv(argv)
-        if not normalized:
-            return argv
-        cmd = normalized[0]
-        if cmd not in zview_cli.KNOWN_COMMANDS:
-            return argv
-        if not _command_wants_runner(cmd, argv):
-            return argv
-
-        has_runner = _has_flag(argv, "-r", "--runner")
-        has_target = _has_flag(argv, "-t", "--runner-target")
-        if has_runner and has_target:
-            return argv
+    def _fill_runner(self, args: argparse.Namespace) -> None:
+        if args.runner is not None and args.runner_target is not None:
+            return
 
         runners_yaml_path = Path("build").resolve() / "zephyr" / "runners.yaml"
         try:
-            runner_config = RunnerConfig(runners_yaml_path)
+            cfg = RunnerConfig(runners_yaml_path)
         except Exception as e:
             self.err(e)
             self.die(
                 "Failed to parse runners.yaml. Please specify runner ('-r') and target ('-t')."
             )
 
-        preferred = None
-        for i, a in enumerate(argv):
-            if a in ("-r", "--runner"):
-                preferred = argv[i + 1] if i + 1 < len(argv) else None
-                break
-            if a.startswith("--runner="):
-                preferred = a.split("=", 1)[1]
-                break
-
-        runner, target_mcu = runner_config.get_config(preferred_runner=preferred)
+        runner, target_mcu = cfg.get_config(preferred_runner=args.runner)
 
         if runner not in zview_cli.AVAILABLE_RUNNERS:
             self.wrn(
@@ -162,11 +115,9 @@ class ZViewCommand(WestCommand):
                 f"the following: {', '.join(zview_cli.AVAILABLE_RUNNERS)}"
             )
             self.wrn("Trying to continue with PyOCD as runner...")
-            runner, target_mcu = runner_config.get_config(preferred_runner="pyocd")
+            runner, target_mcu = cfg.get_config(preferred_runner="pyocd")
 
-        injected: list[str] = []
-        if not has_runner:
-            injected += ["-r", runner]
-        if not has_target and target_mcu:
-            injected += ["-t", str(target_mcu)]
-        return _insert_after_command(argv, injected)
+        if args.runner is None:
+            args.runner = runner
+        if args.runner_target is None and target_mcu is not None:
+            args.runner_target = str(target_mcu)

--- a/src/backend/base.py
+++ b/src/backend/base.py
@@ -77,6 +77,12 @@ class HeapInfo:
 class AbstractScraper(ABC):
     """Common interface for memory-read backends (JLink, pyOCD, GDB RSP)."""
 
+    # True for live probe backends; False for synthetic backends (replay) that
+    # cannot accept runtime mutations — no reconnect, no change to the polling
+    # shape (thread pool, heap fragmentation toggle) mid-stream. Subclasses that
+    # cannot absorb such mutations must set this to False.
+    is_live: bool = True
+
     def __init__(self, target_mcu: str | None):
         self._target_mcu: str | None = target_mcu
         self._is_connected: bool = False

--- a/src/backend/elf_inspector.py
+++ b/src/backend/elf_inspector.py
@@ -300,9 +300,12 @@ class ElfInspector:
         Returns all global variable names whose type is the named struct,
         or None if no such variables were found in the DWARF info.
 
-        The returned list is deduplicated — a symbol appearing in multiple
-        compilation units is reported only once.
+        The returned list is deduplicated (a symbol appearing in multiple
+        compilation units is reported only once) and preserves DWARF
+        discovery order — critical for downstream consumers (ZScraper's
+        polling loop, recording/replay lockstep) that depend on a stable
+        iteration order across processes.
         """
         if struct_name not in self._struct_variables:
             return None
-        return list(set(self._struct_variables[struct_name]))
+        return list(dict.fromkeys(self._struct_variables[struct_name]))

--- a/src/backend/elf_inspector.py
+++ b/src/backend/elf_inspector.py
@@ -59,12 +59,12 @@ class ElfInspector:
         self._little_endian = True
 
         if not self._load_cache():
-            print("Loading ELF. This may take a while...", end="", flush=True)
+            print("Loading ELF. This may take a while...", end="", flush=True, file=sys.stderr)
             self._perform_single_pass_scan()
             self._save_cache()
-            print(" OK.")
+            print(" OK.", file=sys.stderr)
         else:
-            print(f"Loaded cached ELF @ {self._cache_file}")
+            print(f"Loaded cached ELF @ {self._cache_file}", file=sys.stderr)
 
     @staticmethod
     def _resolve_os_cache_dir() -> Path:

--- a/src/backend/gdb.py
+++ b/src/backend/gdb.py
@@ -8,6 +8,7 @@ import contextlib
 import logging
 import socket
 import struct
+import sys
 from collections.abc import Sequence
 
 from backend.base import (
@@ -63,7 +64,7 @@ class GDBScraper(AbstractScraper):
         self._send_packet(b'QStartNoAckMode')
 
         self._is_connected = True
-        print(f"Connected to GDB server at {self.host}:{self.port}")
+        print(f"Connected to GDB server at {self.host}:{self.port}", file=sys.stderr)
         logger.info("Connected to GDB server at %s:%d", self.host, self.port)
 
     def disconnect(self):

--- a/src/backend/recording.py
+++ b/src/backend/recording.py
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-RecordingScraper captures every call issued to a live AbstractScraper and
-streams it to a gzip-compressed NDJSON file. The resulting recording can be
-played back offline through ReplayScraper without a probe or target attached.
-"""
+"""RecordingScraper: AbstractScraper wrapper that streams every call to a gzipped NDJSON file."""
 
 import gzip
 import json
@@ -23,10 +19,9 @@ SCHEMA_VERSION = "zview-recording/1"
 
 class RecordingScraper(AbstractScraper):
     """
-    Wraps an AbstractScraper and serializes every call to a gzip-compressed
-    NDJSON stream. The first line is a header (schema version, endianess,
-    creation timestamp); subsequent lines are call entries in issue order.
-    Bulk ``read_bytes`` payloads are hex-encoded; gzip reclaims the bloat.
+    AbstractScraper wrapper that emits each call as one NDJSON line.
+    First line is a header ({schema, endianess, created_at}); ``read_bytes``
+    payloads are hex-encoded.
     """
 
     def __init__(self, wrapped: AbstractScraper, out_path: Path | str):
@@ -38,10 +33,7 @@ class RecordingScraper(AbstractScraper):
         self.endianess = wrapped.endianess
 
     def _open(self) -> None:
-        """
-        Open the gzip stream and write the header line. Idempotent: repeat
-        calls on an already-open recorder are no-ops.
-        """
+        """Open the gzip stream and write the header. Idempotent."""
         if self._fp is not None:
             return
         # File lifetime spans connect()/disconnect(), tracked via ExitStack.
@@ -57,12 +49,7 @@ class RecordingScraper(AbstractScraper):
         self._fp.write(json.dumps(header) + "\n")
 
     def _emit(self, op: str, args: dict, result=None) -> None:
-        """
-        Append one call entry to the stream. Entries are JSON objects with
-        fields ``t`` (wall-clock timestamp), ``op`` (method name), ``args``
-        (keyword arguments dict) and, for read ops, ``result`` (decoded return
-        value; ``bytes`` payloads are stored as hex strings).
-        """
+        """Append one call entry: ``{t, op, args[, result]}``."""
         if self._fp is None:
             return
         entry: dict = {"t": time.time(), "op": op, "args": args}

--- a/src/backend/recording.py
+++ b/src/backend/recording.py
@@ -97,17 +97,16 @@ class RecordingScraper(AbstractScraper):
         self._emit("read_bytes", {"at": at, "amount": amount}, bytes(result).hex())
         return result
 
-    def read8(self, at: int, amount: int = 1) -> Sequence[int]:
-        result = self._wrapped.read8(at, amount)
-        self._emit("read8", {"at": at, "amount": amount}, list(result))
+    def _record_read(self, op: str, fn, at: int, amount: int) -> Sequence[int]:
+        result = fn(at, amount)
+        self._emit(op, {"at": at, "amount": amount}, list(result))
         return result
+
+    def read8(self, at: int, amount: int = 1) -> Sequence[int]:
+        return self._record_read("read8", self._wrapped.read8, at, amount)
 
     def read32(self, at: int, amount: int = 1) -> Sequence[int]:
-        result = self._wrapped.read32(at, amount)
-        self._emit("read32", {"at": at, "amount": amount}, list(result))
-        return result
+        return self._record_read("read32", self._wrapped.read32, at, amount)
 
     def read64(self, at: int, amount: int = 1) -> Sequence[int]:
-        result = self._wrapped.read64(at, amount)
-        self._emit("read64", {"at": at, "amount": amount}, list(result))
-        return result
+        return self._record_read("read64", self._wrapped.read64, at, amount)

--- a/src/backend/replay.py
+++ b/src/backend/replay.py
@@ -11,6 +11,7 @@ op or args diverge from the next recorded entry.
 
 import gzip
 import json
+import time
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -30,6 +31,10 @@ class ReplayExhausted(ReplayError):
     """Recording ran out of entries before replay completed."""
 
 
+class ReplayComplete(ReplayError):
+    """Caller attempted a new frame past the trailing disconnect — the recording ended cleanly."""
+
+
 class UnsupportedSchema(ReplayError):
     """Recording header advertises a schema this reader does not handle."""
 
@@ -38,15 +43,25 @@ class ReplayScraper(AbstractScraper):
     """
     Replays a recording produced by RecordingScraper. Strict: every call must
     match the next entry's op and args, else ReplayMismatch is raised. Running
-    past the end raises ReplayExhausted.
+    past the end raises ReplayExhausted. When ``honor_timing`` is True (default),
+    each ``_next`` call sleeps until the recorded wall-clock delta has elapsed,
+    reproducing the original session cadence.
     """
 
-    def __init__(self, source_path: Path | str):
+    # A replay cursor can neither rewind nor absorb changes to the polling
+    # shape (thread pool reductions, heap fragmentation toggles, etc.) without
+    # drifting against the recording.
+    is_live = False
+
+    def __init__(self, source_path: Path | str, honor_timing: bool = True):
         super().__init__(target_mcu=None)
         self._source_path = Path(source_path)
         self._entries: list[dict] = []
         self._cursor: int = 0
         self._loaded: bool = False
+        self._honor_timing = honor_timing
+        self._anchor_wall: float | None = None
+        self._anchor_recording: float | None = None
 
     def _load(self) -> None:
         """
@@ -83,19 +98,50 @@ class ReplayScraper(AbstractScraper):
         Advance the cursor by one entry and return its stored result. The
         caller's ``op`` and ``args`` must match the entry exactly; any drift
         raises ReplayMismatch, and advancing past the last entry raises
-        ReplayExhausted.
+        ReplayExhausted. When ``honor_timing`` is enabled, sleeps until the
+        entry's recorded timestamp in wall-clock, anchored on the first call.
         """
         if self._cursor >= len(self._entries):
             raise ReplayExhausted(f"Recording exhausted before op {op}({args}).")
 
         entry = self._entries[self._cursor]
+
+        # A caller starting a new frame while the cursor sits on the trailing
+        # ``disconnect`` entry means the recording has been fully consumed —
+        # that's a clean end-of-stream, not a drift.
+        if op == "begin_batch" and entry["op"] == "disconnect":
+            raise ReplayComplete(f"Recording ended cleanly at index {self._cursor}.")
+
         if entry["op"] != op or entry["args"] != args:
             raise ReplayMismatch(
                 f"Replay drift at index {self._cursor}: "
                 f"expected {entry['op']}({entry['args']}), got {op}({args})."
             )
+
+        if self._honor_timing:
+            self._pace_to(entry.get("t"))
+
         self._cursor += 1
         return entry.get("result")
+
+    def _pace_to(self, recording_t: float | None) -> None:
+        """
+        Sleep until the wall-clock matches the recorded timestamp's position
+        in the session timeline. No-op if the entry lacks a timestamp.
+        """
+        if recording_t is None:
+            return
+
+        now = time.monotonic()
+        if self._anchor_wall is None:
+            self._anchor_wall = now
+            self._anchor_recording = recording_t
+            return
+
+        target = self._anchor_wall + (recording_t - self._anchor_recording)
+        delay = target - now
+        if delay > 0:
+            time.sleep(delay)
 
     def connect(self) -> None:
         self._load()

--- a/src/backend/replay.py
+++ b/src/backend/replay.py
@@ -103,7 +103,17 @@ class ReplayScraper(AbstractScraper):
         self._is_connected = True
 
     def disconnect(self) -> None:
-        self._next("disconnect", {})
+        """
+        Tolerant: consume the recorded ``disconnect`` entry when the cursor
+        is positioned at one (clean end-of-recording shutdown); otherwise
+        just mark the scraper disconnected so the caller may stop mid-stream.
+        """
+        if (
+            self._cursor < len(self._entries)
+            and self._entries[self._cursor]["op"] == "disconnect"
+            and self._entries[self._cursor]["args"] == {}
+        ):
+            self._cursor += 1
         self._is_connected = False
 
     def begin_batch(self) -> None:

--- a/src/backend/replay.py
+++ b/src/backend/replay.py
@@ -2,12 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-ReplayScraper reads an NDJSON-over-gzip recording produced by RecordingScraper
-and satisfies the AbstractScraper interface by returning each recorded result
-in sequence. Strict drift detection raises ReplayMismatch when the caller's
-op or args diverge from the next recorded entry.
-"""
+"""ReplayScraper: AbstractScraper backed by a RecordingScraper output file."""
 
 import gzip
 import json
@@ -41,11 +36,10 @@ class UnsupportedSchema(ReplayError):
 
 class ReplayScraper(AbstractScraper):
     """
-    Replays a recording produced by RecordingScraper. Strict: every call must
-    match the next entry's op and args, else ReplayMismatch is raised. Running
-    past the end raises ReplayExhausted. When ``honor_timing`` is True (default),
-    each ``_next`` call sleeps until the recorded wall-clock delta has elapsed,
-    reproducing the original session cadence.
+    Replays a RecordingScraper file. Strict: every call's op and args must
+    match the next recorded entry, else raises ReplayMismatch. Past the end
+    raises ReplayExhausted. ``honor_timing=True`` paces calls to the recorded
+    timestamps.
     """
 
     # A replay cursor can neither rewind nor absorb changes to the polling
@@ -64,11 +58,7 @@ class ReplayScraper(AbstractScraper):
         self._anchor_recording: float | None = None
 
     def _load(self) -> None:
-        """
-        Parse the header and eagerly buffer every entry. Idempotent: subsequent
-        calls are no-ops. Raises UnsupportedSchema if the header is missing or
-        advertises a schema this reader does not understand.
-        """
+        """Parse header and buffer all entries. Idempotent. Raises UnsupportedSchema."""
         if self._loaded:
             return
 
@@ -95,11 +85,9 @@ class ReplayScraper(AbstractScraper):
 
     def _next(self, op: str, args: dict):
         """
-        Advance the cursor by one entry and return its stored result. The
-        caller's ``op`` and ``args`` must match the entry exactly; any drift
-        raises ReplayMismatch, and advancing past the last entry raises
-        ReplayExhausted. When ``honor_timing`` is enabled, sleeps until the
-        entry's recorded timestamp in wall-clock, anchored on the first call.
+        Advance cursor and return the entry's stored result.
+        Raises ReplayMismatch on op/args drift, ReplayExhausted past end,
+        ReplayComplete when ``op == 'begin_batch'`` lands on a trailing ``disconnect``.
         """
         if self._cursor >= len(self._entries):
             raise ReplayExhausted(f"Recording exhausted before op {op}({args}).")
@@ -125,10 +113,7 @@ class ReplayScraper(AbstractScraper):
         return entry.get("result")
 
     def _pace_to(self, recording_t: float | None) -> None:
-        """
-        Sleep until the wall-clock matches the recorded timestamp's position
-        in the session timeline. No-op if the entry lacks a timestamp.
-        """
+        """Sleep until the wall-clock matches ``recording_t`` (anchored on first call)."""
         if recording_t is None:
             return
 
@@ -149,11 +134,7 @@ class ReplayScraper(AbstractScraper):
         self._is_connected = True
 
     def disconnect(self) -> None:
-        """
-        Tolerant: consume the recorded ``disconnect`` entry when the cursor
-        is positioned at one (clean end-of-recording shutdown); otherwise
-        just mark the scraper disconnected so the caller may stop mid-stream.
-        """
+        """Consume a trailing ``disconnect`` entry if present; mark disconnected."""
         if (
             self._cursor < len(self._entries)
             and self._entries[self._cursor]["op"] == "disconnect"

--- a/src/frontend/tui/views/thread_list.py
+++ b/src/frontend/tui/views/thread_list.py
@@ -195,6 +195,10 @@ class ThreadListView(BaseStateView):
                 self._invert_sorting = not self._invert_sorting
 
             case SpecialCode.RECONNECT:
+                if not self.controller.scraper._m_scraper.is_live:
+                    self.controller.status_message = "Refresh is not available in replay mode."
+                    return None
+
                 self.controller.status_message = "Refreshing thread list..."
 
                 # Force the scraper to re-read the kernel's thread linked-list

--- a/src/frontend/zview_tui.py
+++ b/src/frontend/zview_tui.py
@@ -114,6 +114,10 @@ class ZView:
 
     def attempt_reconnect(self):
         """Executes hardware reconnection and data pipeline reset."""
+        if not self.scraper._m_scraper.is_live:
+            self.status_message = "Reconnect is not available in replay mode."
+            return
+
         self.status_message = "Attempting to reconnect..."
         self.scraper.finish_polling_thread()
         self.scraper._m_scraper.disconnect()
@@ -161,9 +165,15 @@ class ZView:
             self.status_message = f"Warning: {new_state.name} is not yet implemented."
             return
 
+        # Replay backends cannot absorb polling-shape mutations without drifting
+        # against the recording. Views still transition; the display filters
+        # from the full frame on its own.
+        live = self.scraper._m_scraper.is_live
+
         match new_state:
             case ZViewState.THREAD_LIST_VIEW:
-                self.scraper.thread_pool = list(self.scraper.all_threads.values())
+                if live:
+                    self.scraper.thread_pool = list(self.scraper.all_threads.values())
                 self.purge_queue()
 
             case ZViewState.THREAD_DETAIL_VIEW:
@@ -171,7 +181,10 @@ class ZView:
                     return
 
                 target_thread = self.scraper.all_threads.get(self.detailing_thread)
-                if target_thread:
+                if target_thread is None:
+                    return
+
+                if live:
                     new_pool = [target_thread]
                     idle_t = next(
                         (
@@ -183,17 +196,19 @@ class ZView:
                     )
                     if idle_t and idle_t.address != new_pool[0].address:
                         new_pool.append(idle_t)
-
                     self.scraper.thread_pool = new_pool
-                    self.purge_queue()
+
+                self.purge_queue()
 
             case ZViewState.HEAP_LIST_VIEW:
-                self.scraper.extra_info_heap_address = None
-                self.scraper.thread_pool = []
+                if live:
+                    self.scraper.extra_info_heap_address = None
+                    self.scraper.thread_pool = []
                 self.purge_queue()
 
             case ZViewState.HEAPS_DETAIL_VIEW:
-                self.scraper.extra_info_heap_address = self.detailing_heap_address
+                if live:
+                    self.scraper.extra_info_heap_address = self.detailing_heap_address
                 self.purge_queue()
 
         self.state = new_state
@@ -211,6 +226,10 @@ class ZView:
         if data.get("fatal_error"):
             self.state = ZViewState.FATAL_ERROR
             self.status_message = f"TARGET LOST\n\n{data['fatal_error']}"
+            return
+
+        if data.get("replay_complete"):
+            self.status_message = "Recording ended — replay complete."
             return
 
         if data.get("error"):

--- a/src/kernel/heaps.py
+++ b/src/kernel/heaps.py
@@ -15,12 +15,9 @@ def walk_heap_fragmentation(
     end_chunk_offset: int,
 ) -> list[dict]:
     """
-    Enumerate a Zephyr sys_heap's chunks via a single bulk memory read.
-    Each chunk is returned as ``{"used": bool, "size": int}`` in byte units.
-    Returns an empty list when ``z_heap_addr`` is null or the heap's chunk
-    count is zero. Raises ``ValueError`` when the heap header cannot be
-    decoded or exceeds 32 MB, and ``RuntimeError`` on a zero-size chunk
-    (infinite-loop guard).
+    Enumerate a sys_heap's chunks. Returns ``[{"used": bool, "size": int}]``
+    in byte units, or ``[]`` when the heap is null/empty. Raises ``ValueError``
+    on a corrupted header or sizes >32 MB, ``RuntimeError`` on a zero-size chunk.
     """
     if z_heap_addr == 0:
         return []

--- a/src/kernel/layout.py
+++ b/src/kernel/layout.py
@@ -9,13 +9,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class KernelLayout:
-    """
-    Byte offsets into Zephyr kernel structs, resolved from the ELF's DWARF.
-
-    All fields are simple integer offsets. The owning ``ZScraper`` knows the
-    base addresses (``_kernel_base_address``, per-thread struct address, per
-    heap struct pointer) and adds them to these offsets at read time.
-    """
+    """Byte offsets into Zephyr kernel structs, resolved from DWARF."""
 
     # Mandatory: thread walking
     threads_head: int  # z_kernel.threads

--- a/src/kernel/layout.py
+++ b/src/kernel/layout.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DWARF-resolved offsets needed to walk Zephyr kernel objects."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KernelLayout:
+    """
+    Byte offsets into Zephyr kernel structs, resolved from the ELF's DWARF.
+
+    All fields are simple integer offsets. The owning ``ZScraper`` knows the
+    base addresses (``_kernel_base_address``, per-thread struct address, per
+    heap struct pointer) and adds them to these offsets at read time.
+    """
+
+    # Mandatory: thread walking
+    threads_head: int  # z_kernel.threads
+    thread_next: int  # k_thread.next_thread
+    stack_start: int  # _thread_stack_info.start (resolved through k_thread.stack_info)
+    stack_size: int  # _thread_stack_info.size (resolved through k_thread.stack_info)
+
+    # Optional: thread names (CONFIG_THREAD_NAME)
+    thread_name: int | None = None
+
+    # Optional: per-thread CPU usage (CONFIG_THREAD_RUNTIME_STATS)
+    cpu_usage: int | None = None  # z_kernel.usage
+    thread_usage: int | None = None  # k_thread → k_cycle_stats.total
+
+    # Optional: heap stats (CONFIG_SYS_HEAP_RUNTIME_STATS)
+    heap_free_bytes: int | None = None
+    heap_allocated_bytes: int | None = None
+    heap_max_allocated_bytes: int | None = None
+    heap_end_chunk: int | None = None

--- a/src/kernel/threads.py
+++ b/src/kernel/threads.py
@@ -21,9 +21,8 @@ def walk_thread_list(
     max_threads: int = 64,
 ) -> dict[str, ThreadInfo]:
     """
-    Walk the kernel thread linked list starting at ``threads_head_address``
-    and return a ``{name: ThreadInfo}`` map. Batches the entire walk via the
-    scraper's ``begin_batch``/``end_batch`` hooks. Raises ``RuntimeError``
+    Walk the kernel thread linked list and return ``{name: ThreadInfo}``.
+    Wrapped in a single ``begin_batch``/``end_batch``. Raises ``RuntimeError``
     when the head pointer cannot be read.
     """
     try:

--- a/src/kernel/threads.py
+++ b/src/kernel/threads.py
@@ -8,13 +8,14 @@ from typing import Literal
 
 from backend.base import AbstractScraper, ThreadInfo
 from backend.elf_inspector import ElfInspector
+from kernel.layout import KernelLayout
 
 
 def walk_thread_list(
     scraper: AbstractScraper,
     elf: ElfInspector,
     threads_head_address: int,
-    offsets: dict,
+    layout: KernelLayout,
     endianess: Literal["little", "big"],
     has_names: bool,
     max_threads: int = 64,
@@ -37,10 +38,12 @@ def walk_thread_list(
 
     stack_struct_size = elf.get_struct_size("k_thread")
     words_to_read = stack_struct_size // 4
-    next_ptr_word_idx = offsets["k_thread"]["next_thread"] // 4
-    stack_start_word_idx = offsets["thread_info"]["stack_start"] // 4
-    name_word_idx = offsets["k_thread"]["name"] // 4 if has_names else 0
-    stack_size_word_idx = offsets["thread_info"]["stack_size"] // 4
+    next_ptr_word_idx = layout.thread_next // 4
+    stack_start_word_idx = layout.stack_start // 4
+    stack_size_word_idx = layout.stack_size // 4
+    name_word_idx = (
+        (layout.thread_name // 4) if (has_names and layout.thread_name is not None) else 0
+    )
 
     threads: dict[str, ThreadInfo] = {}
     for _ in range(max_threads):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -248,7 +248,6 @@ class ZScraper:
             daemon=True,
         )
         self._stop_event = stop_event
-        self._polling_thread.daemon = True
         self._polling_thread.start()
 
     def finish_polling_thread(self):
@@ -307,9 +306,8 @@ class ZScraper:
                     self.last_cpu_cycles = current_cpu_cycles
                     if cpu_cycles_delta > 0:
                         self.last_cpu_delta = cpu_cycles_delta
-                    elif (
-                        cpu_cycles_delta <= 0
-                    ):  # When current_cpu_cycles is 0 due to context resets
+                    else:
+                        # current_cpu_cycles wrapped or reset; keep last positive delta.
                         cpu_cycles_delta = self.last_cpu_delta
                 else:
                     cpu_cycles_delta = -1

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -255,6 +255,8 @@ class ZScraper:
 
         self._polling_thread = None
 
+    _MAX_TOLERATED_ERRORS = 3
+
     def _poll_thread_worker(
         self,
         data_queue: queue.Queue,
@@ -262,19 +264,11 @@ class ZScraper:
         inspection_period: float,
     ):
         """
-        Worker function executed by the polling thread.
-
-        Connects to the MCU via J-Link, analyzes Zephyr kernel symbols from the ELF
-        file, and continuously reads and processes runtime data, pushing it to
-        `data_queue`.
-
-        Args:
-            data_queue: A queue for sending processed data to the main UI thread.
-            stop_event: An event to signal the polling thread to terminate.
+        Polling thread entry point. Connects, then loops one frame at a time,
+        delegating per-phase work to the helpers below. Tolerates up to
+        ``_MAX_TOLERATED_ERRORS`` transient read faults before declaring the
+        target lost; ends cleanly when a recording exhausts.
         """
-        consecutive_errors = 0
-        MAX_TOLERATED_ERRORS = 3
-
         try:
             if not self._m_scraper.is_connected:
                 self._m_scraper.connect()
@@ -282,186 +276,23 @@ class ZScraper:
             data_queue.put({"fatal_error": f"Failed to connect to target: {e}"})
             return
 
+        consecutive_errors = 0
         while not stop_event.is_set():
             in_batch = False
-            heap_info = []
             try:
                 self._m_scraper.begin_batch()
                 in_batch = True
 
-                if self.has_usage:
-                    try:
-                        current_cpu_cycles = self._m_scraper.read32(self._cpu_usage_address)[0]
-                    except Exception as e:
-                        raise RuntimeError(f"Error reading global CPU cycles: {e}") from e
+                cpu_cycles_delta = self._read_cpu_cycles_delta()
+                polled_raw, cpu_cycles_delta = self._poll_threads(cpu_cycles_delta)
+                final_threads = self._finalize_threads(polled_raw, cpu_cycles_delta)
 
-                    cpu_cycles_delta = current_cpu_cycles - self.last_cpu_cycles
-                    self.last_cpu_cycles = current_cpu_cycles
-                    if cpu_cycles_delta > 0:
-                        self.last_cpu_delta = cpu_cycles_delta
-                    else:
-                        # current_cpu_cycles wrapped or reset; keep last positive delta.
-                        cpu_cycles_delta = self.last_cpu_delta
-                else:
-                    cpu_cycles_delta = -1
-
-                if self.thread_pool is None:
-                    raise RuntimeError("Thread pool is uninitialized.")
-
-                polled_raw_data = []
-                for thread_info in self.thread_pool:
-                    if self.has_usage:
-                        try:
-                            thread_usage = self._m_scraper.read64(
-                                thread_info.address + self._layout.thread_usage
-                            )[0]
-                        except Exception as e:
-                            raise RuntimeError(
-                                f"Error polling thread usage {thread_info.name}: {e}"
-                            ) from e
-
-                        thread_usage_delta = thread_usage - self.last_thread_cycles.get(
-                            thread_info.address, 0
-                        )
-                        self.last_thread_cycles[thread_info.address] = thread_usage
-
-                        if thread_info.address == self.idle_threads_address:
-                            cpu_cycles_delta += thread_usage_delta
-
-                        is_active = thread_usage_delta > 0
-                    else:
-                        thread_usage_delta = 0
-                        is_active = False
-
-                    try:
-                        watermark = self._m_scraper.calculate_dynamic_watermark(
-                            thread_info.stack_start,
-                            thread_info.stack_size,
-                            thread_id=thread_info.address,
-                        )
-                    except Exception as e:
-                        raise RuntimeError(
-                            f"Error polling stack watermark for {thread_info.name}: {e}"
-                        ) from e
-
-                    stack_usage_pct = (
-                        (watermark / thread_info.stack_size * 100)
-                        if thread_info.stack_size > 0
-                        else 0.0
-                    )
-
-                    polled_raw_data.append(
-                        {
-                            "info": thread_info,
-                            "usage_delta": thread_usage_delta,
-                            "is_active": is_active,
-                            "watermark": watermark,
-                            "stack_usage_pct": stack_usage_pct,
-                        }
-                    )
-
-                idle_thread_data = next(
-                    (d for d in polled_raw_data if d["info"].address == self.idle_threads_address),
-                    None,
-                )
-
-                if idle_thread_data:
-                    active_cycles_total = cpu_cycles_delta - idle_thread_data["usage_delta"]
-                else:
-                    active_cycles_total = cpu_cycles_delta
-
-                final_threads = []
-                for data in polled_raw_data:
-                    # Absolute CPU % (t / total_system_time)
-                    absolute_cpu = (
-                        (data["usage_delta"] / cpu_cycles_delta * 100)
-                        if cpu_cycles_delta > 0
-                        else 0.0
-                    )
-
-                    # Relative Load % (t / total_active_time)
-                    if data["info"].address == self.idle_threads_address:
-                        load_pct = 0.0
-                    elif active_cycles_total > 0:
-                        load_pct = min((data["usage_delta"] / active_cycles_total) * 100.0, 100.0)
-                    else:
-                        load_pct = 0.0
-
-                    final_runtime = ThreadRuntime(
-                        cpu=load_pct,
-                        cpu_normalized=absolute_cpu,
-                        active=data["is_active"],
-                        stack_watermark=data["watermark"],
-                        stack_watermark_percent=data["stack_usage_pct"],
-                    )
-                    final_threads.append(
-                        ThreadInfo(
-                            address=data["info"].address,
-                            stack_start=data["info"].stack_start,
-                            stack_size=data["info"].stack_size,
-                            name=data["info"].name,
-                            runtime=final_runtime,
-                        )
-                    )
-
+                frame: dict = {"threads": final_threads}
                 if self.has_heaps:
-                    for heap_name, heap_addresses in self._k_heap_addresses.items():
-                        for heap_address in heap_addresses:
-                            try:
-                                heap_address_val = self._m_scraper.read32(heap_address)[0]
-                                free_bytes = self._m_scraper.read32(
-                                    heap_address_val + self._layout.heap_free_bytes
-                                )[0]
-                                allocated_bytes = self._m_scraper.read32(
-                                    heap_address_val + self._layout.heap_allocated_bytes
-                                )[0]
-                                max_allocated_bytes = self._m_scraper.read32(
-                                    heap_address_val + self._layout.heap_max_allocated_bytes
-                                )[0]
-                            except Exception as e:
-                                data_queue.put(
-                                    {"error": f"Error reading heap info for {heap_name}: {e}"},
-                                    block=False,
-                                )
-                                continue
+                    frame["heaps"] = self._poll_heaps(data_queue)
+                data_queue.put(frame, block=False)
 
-                            chunks = None
-                            if self.extra_info_heap_address == heap_address_val:
-                                try:
-                                    chunks = self.get_heap_fragmentation(heap_address_val)
-                                except Exception as e:
-                                    data_queue.put(
-                                        {"error": f"Error reading sparsity for {heap_name}: {e}"},
-                                        block=False,
-                                    )
-
-                            total_heap_size = allocated_bytes + free_bytes
-                            heap_usage_pct = (
-                                (allocated_bytes / total_heap_size * 100)
-                                if total_heap_size > 0
-                                else 0.0
-                            )
-
-                            heap_info.append(
-                                HeapInfo(
-                                    heap_name,
-                                    heap_address_val,
-                                    free_bytes,
-                                    allocated_bytes,
-                                    max_allocated_bytes,
-                                    heap_usage_pct,
-                                    chunks,
-                                )
-                            )
-
-                if self.has_heaps:
-                    data_queue.put({"threads": final_threads, "heaps": heap_info}, block=False)
-                else:
-                    data_queue.put({"threads": final_threads}, block=False)
-
-                # Frame successful. Reset error counter.
                 consecutive_errors = 0
-
             except queue.Full:
                 pass
             except ReplayComplete as e:
@@ -469,23 +300,187 @@ class ZScraper:
                 break
             except Exception as e:
                 consecutive_errors += 1
-                if consecutive_errors >= MAX_TOLERATED_ERRORS:
-                    data_queue.put(
-                        {"fatal_error": f"Target lost after {MAX_TOLERATED_ERRORS} retries: {e}"}
-                    )
-                    break  # Terminate loop cleanly
-                else:
+                if consecutive_errors >= self._MAX_TOLERATED_ERRORS:
                     data_queue.put(
                         {
-                            "error": f"Transient read fault "
-                            f"({consecutive_errors}/{MAX_TOLERATED_ERRORS}): {e}"
-                        },
-                        block=False,
+                            "fatal_error": f"Target lost after "
+                            f"{self._MAX_TOLERATED_ERRORS} retries: {e}"
+                        }
                     )
-
+                    break
+                data_queue.put(
+                    {
+                        "error": f"Transient read fault "
+                        f"({consecutive_errors}/{self._MAX_TOLERATED_ERRORS}): {e}"
+                    },
+                    block=False,
+                )
             finally:
                 if in_batch:
                     with contextlib.suppress(Exception):
                         self._m_scraper.end_batch()
 
             time.sleep(inspection_period)
+
+    def _read_cpu_cycles_delta(self) -> int:
+        """Return the cycles elapsed since the last frame, or -1 when usage tracking is off."""
+        if not self.has_usage:
+            return -1
+
+        try:
+            current = self._m_scraper.read32(self._cpu_usage_address)[0]
+        except Exception as e:
+            raise RuntimeError(f"Error reading global CPU cycles: {e}") from e
+
+        delta = current - self.last_cpu_cycles
+        self.last_cpu_cycles = current
+        if delta > 0:
+            self.last_cpu_delta = delta
+            return delta
+        # current_cpu_cycles wrapped or reset; keep last positive delta.
+        return self.last_cpu_delta
+
+    def _poll_threads(self, cpu_cycles_delta: int) -> tuple[list[dict], int]:
+        """
+        Per-thread loop: read usage + watermark, accumulate raw polling state.
+        The idle thread's usage delta is folded back into ``cpu_cycles_delta``,
+        so the second return value may differ from the input.
+        """
+        if self.thread_pool is None:
+            raise RuntimeError("Thread pool is uninitialized.")
+
+        polled: list[dict] = []
+        for thread in self.thread_pool:
+            if self.has_usage:
+                try:
+                    thread_usage = self._m_scraper.read64(
+                        thread.address + self._layout.thread_usage
+                    )[0]
+                except Exception as e:
+                    raise RuntimeError(f"Error polling thread usage {thread.name}: {e}") from e
+
+                usage_delta = thread_usage - self.last_thread_cycles.get(thread.address, 0)
+                self.last_thread_cycles[thread.address] = thread_usage
+
+                if thread.address == self.idle_threads_address:
+                    cpu_cycles_delta += usage_delta
+
+                is_active = usage_delta > 0
+            else:
+                usage_delta = 0
+                is_active = False
+
+            try:
+                watermark = self._m_scraper.calculate_dynamic_watermark(
+                    thread.stack_start,
+                    thread.stack_size,
+                    thread_id=thread.address,
+                )
+            except Exception as e:
+                raise RuntimeError(f"Error polling stack watermark for {thread.name}: {e}") from e
+
+            stack_usage_pct = (
+                (watermark / thread.stack_size * 100) if thread.stack_size > 0 else 0.0
+            )
+
+            polled.append(
+                {
+                    "info": thread,
+                    "usage_delta": usage_delta,
+                    "is_active": is_active,
+                    "watermark": watermark,
+                    "stack_usage_pct": stack_usage_pct,
+                }
+            )
+
+        return polled, cpu_cycles_delta
+
+    def _finalize_threads(self, polled: list[dict], cpu_cycles_delta: int) -> list[ThreadInfo]:
+        """Compute per-thread CPU% / relative load and emit the final ThreadInfo list."""
+        idle = next(
+            (d for d in polled if d["info"].address == self.idle_threads_address),
+            None,
+        )
+        active_total = (cpu_cycles_delta - idle["usage_delta"]) if idle else cpu_cycles_delta
+
+        final: list[ThreadInfo] = []
+        for data in polled:
+            absolute_cpu = (
+                (data["usage_delta"] / cpu_cycles_delta * 100) if cpu_cycles_delta > 0 else 0.0
+            )
+
+            if data["info"].address == self.idle_threads_address:
+                load_pct = 0.0
+            elif active_total > 0:
+                load_pct = min((data["usage_delta"] / active_total) * 100.0, 100.0)
+            else:
+                load_pct = 0.0
+
+            runtime = ThreadRuntime(
+                cpu=load_pct,
+                cpu_normalized=absolute_cpu,
+                active=data["is_active"],
+                stack_watermark=data["watermark"],
+                stack_watermark_percent=data["stack_usage_pct"],
+            )
+            final.append(
+                ThreadInfo(
+                    address=data["info"].address,
+                    stack_start=data["info"].stack_start,
+                    stack_size=data["info"].stack_size,
+                    name=data["info"].name,
+                    runtime=runtime,
+                )
+            )
+        return final
+
+    def _poll_heaps(self, data_queue: queue.Queue) -> list[HeapInfo]:
+        """
+        Read each k_heap's metadata and emit a HeapInfo list. Per-heap read
+        failures and fragmentation-walk failures are reported as non-fatal
+        ``error`` frames on ``data_queue`` and skip that heap.
+        """
+        heaps: list[HeapInfo] = []
+        for heap_name, heap_addresses in self._k_heap_addresses.items():
+            for heap_address in heap_addresses:
+                try:
+                    heap_struct = self._m_scraper.read32(heap_address)[0]
+                    free = self._m_scraper.read32(heap_struct + self._layout.heap_free_bytes)[0]
+                    allocated = self._m_scraper.read32(
+                        heap_struct + self._layout.heap_allocated_bytes
+                    )[0]
+                    max_allocated = self._m_scraper.read32(
+                        heap_struct + self._layout.heap_max_allocated_bytes
+                    )[0]
+                except Exception as e:
+                    data_queue.put(
+                        {"error": f"Error reading heap info for {heap_name}: {e}"},
+                        block=False,
+                    )
+                    continue
+
+                chunks = None
+                if self.extra_info_heap_address == heap_struct:
+                    try:
+                        chunks = self.get_heap_fragmentation(heap_struct)
+                    except Exception as e:
+                        data_queue.put(
+                            {"error": f"Error reading sparsity for {heap_name}: {e}"},
+                            block=False,
+                        )
+
+                total = allocated + free
+                usage_pct = (allocated / total * 100) if total > 0 else 0.0
+
+                heaps.append(
+                    HeapInfo(
+                        heap_name,
+                        heap_struct,
+                        free,
+                        allocated,
+                        max_allocated,
+                        usage_pct,
+                        chunks,
+                    )
+                )
+        return heaps

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -18,6 +18,7 @@ from typing import Literal
 
 from backend.base import AbstractScraper, HeapInfo, ThreadInfo, ThreadRuntime
 from backend.elf_inspector import ElfInspector
+from backend.replay import ReplayComplete
 from kernel.heaps import walk_heap_fragmentation
 from kernel.threads import walk_thread_list
 
@@ -473,6 +474,9 @@ class ZScraper:
 
             except queue.Full:
                 pass
+            except ReplayComplete as e:
+                data_queue.put({"replay_complete": str(e)})
+                break
             except Exception as e:
                 consecutive_errors += 1
                 if consecutive_errors >= MAX_TOLERATED_ERRORS:

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-ZScraper coordinates an AbstractScraper backend, a DWARF-resolved ElfInspector,
-and the kernel-object walkers, owning the polling thread that produces frames
-of thread + heap state for the TUI.
-"""
+"""ZScraper: backend + ELF + kernel walkers + polling thread."""
 
 import contextlib
 import logging
@@ -61,7 +57,7 @@ class ZScraper:
             self._discover_heap_addresses()
 
     def _resolve_layout(self) -> KernelLayout:
-        """Resolve all DWARF-derived offsets, dropping optional features that don't apply."""
+        """Resolve DWARF-derived offsets. Sets ``has_*`` flags for missing features."""
         elf = self._elf_inspector
         stack_info = elf.get_struct_member_offset("k_thread", "stack_info")
 
@@ -130,7 +126,7 @@ class ZScraper:
             self._cpu_usage_address = self._kernel_base_address + self._layout.cpu_usage
 
     def _baseline_cpu_cycles(self) -> None:
-        """Read the initial CPU cycle counter so the first polling delta has an anchor."""
+        """Read and store the initial CPU cycle counter."""
         self._m_scraper.begin_batch()
         self.init_cpu_cycles = self._m_scraper.read64(self._cpu_usage_address)[0]
         self._m_scraper.end_batch()
@@ -139,7 +135,7 @@ class ZScraper:
         self.last_thread_cycles: dict = {}
 
     def _discover_heap_addresses(self) -> None:
-        """Locate every ``k_heap`` global and store its address(es). Disables heaps if none."""
+        """Populate ``_k_heap_addresses`` from ``k_heap`` globals; clears ``has_heaps`` if none."""
         elf = self._elf_inspector
         names = elf.find_struct_variable_names("k_heap") or []
         if not names:
@@ -202,11 +198,7 @@ class ZScraper:
         self.thread_pool = list(self.all_threads.values())
 
     def reset_runtime_state(self):
-        """
-        Drop all per-thread caches and re-baseline CPU cycle counters.
-        Call this whenever the target has been reset or reconnected so that
-        stale watermark assumptions and cycle deltas do not leak across sessions.
-        """
+        """Clear watermark and CPU-cycle caches, then re-read the initial cycle counter."""
         self._m_scraper.watermark_cache.clear()
 
         if not self.has_usage:
@@ -227,9 +219,7 @@ class ZScraper:
         stop_event: threading.Event,
         inspection_period: float,
     ):
-        """
-        Starts a separate daemon thread to continuously poll data from the MCU.
-        """
+        """Start the polling daemon thread. No-op if one is already running."""
         if self._polling_thread is not None:
             data_queue.put({"error": "Already started..."})
             return
@@ -263,12 +253,7 @@ class ZScraper:
         stop_event: threading.Event,
         inspection_period: float,
     ):
-        """
-        Polling thread entry point. Connects, then loops one frame at a time,
-        delegating per-phase work to the helpers below. Tolerates up to
-        ``_MAX_TOLERATED_ERRORS`` transient read faults before declaring the
-        target lost; ends cleanly when a recording exhausts.
-        """
+        """Polling thread entry point. Tolerates ``_MAX_TOLERATED_ERRORS`` transient faults."""
         try:
             if not self._m_scraper.is_connected:
                 self._m_scraper.connect()
@@ -323,7 +308,7 @@ class ZScraper:
             time.sleep(inspection_period)
 
     def _read_cpu_cycles_delta(self) -> int:
-        """Return the cycles elapsed since the last frame, or -1 when usage tracking is off."""
+        """Cycles elapsed since the last frame; ``-1`` when ``has_usage`` is False."""
         if not self.has_usage:
             return -1
 
@@ -341,11 +326,7 @@ class ZScraper:
         return self.last_cpu_delta
 
     def _poll_threads(self, cpu_cycles_delta: int) -> tuple[list[dict], int]:
-        """
-        Per-thread loop: read usage + watermark, accumulate raw polling state.
-        The idle thread's usage delta is folded back into ``cpu_cycles_delta``,
-        so the second return value may differ from the input.
-        """
+        """Read per-thread usage + watermark. Returns (raw_data, adjusted_cpu_cycles_delta)."""
         if self.thread_pool is None:
             raise RuntimeError("Thread pool is uninitialized.")
 
@@ -396,7 +377,7 @@ class ZScraper:
         return polled, cpu_cycles_delta
 
     def _finalize_threads(self, polled: list[dict], cpu_cycles_delta: int) -> list[ThreadInfo]:
-        """Compute per-thread CPU% / relative load and emit the final ThreadInfo list."""
+        """Build ``ThreadInfo`` objects from raw polling state, computing CPU% and load%."""
         idle = next(
             (d for d in polled if d["info"].address == self.idle_threads_address),
             None,
@@ -435,11 +416,7 @@ class ZScraper:
         return final
 
     def _poll_heaps(self, data_queue: queue.Queue) -> list[HeapInfo]:
-        """
-        Read each k_heap's metadata and emit a HeapInfo list. Per-heap read
-        failures and fragmentation-walk failures are reported as non-fatal
-        ``error`` frames on ``data_queue`` and skip that heap.
-        """
+        """Read all heap metadata. Per-heap read failures emit ``error`` frames and are skipped."""
         heaps: list[HeapInfo] = []
         for heap_name, heap_addresses in self._k_heap_addresses.items():
             for heap_address in heap_addresses:

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -20,6 +20,7 @@ from backend.base import AbstractScraper, HeapInfo, ThreadInfo, ThreadRuntime
 from backend.elf_inspector import ElfInspector
 from backend.replay import ReplayComplete
 from kernel.heaps import walk_heap_fragmentation
+from kernel.layout import KernelLayout
 from kernel.threads import walk_thread_list
 
 logger = logging.getLogger("zview.scraper")
@@ -50,110 +51,102 @@ class ZScraper:
 
         self._MAX_THREADS: int = max_threads
 
-        self._offsets = {
-            "kernel": {
-                "cpu": self._elf_inspector.get_struct_member_offset("z_kernel", "cpus"),
-                "threads": self._elf_inspector.get_struct_member_offset("z_kernel", "threads"),
-            },
-            "k_thread": {
-                "base": self._elf_inspector.get_struct_member_offset("k_thread", "base"),
-                "stack_info": self._elf_inspector.get_struct_member_offset(
-                    "k_thread", "stack_info"
-                ),
-                "next_thread": self._elf_inspector.get_struct_member_offset(
-                    "k_thread", "next_thread"
-                ),
-            },
+        self._layout = self._resolve_layout()
+        self._resolve_addresses()
+
+        if self.has_usage:
+            self._baseline_cpu_cycles()
+
+        if self.has_heaps:
+            self._discover_heap_addresses()
+
+    def _resolve_layout(self) -> KernelLayout:
+        """Resolve all DWARF-derived offsets, dropping optional features that don't apply."""
+        elf = self._elf_inspector
+        stack_info = elf.get_struct_member_offset("k_thread", "stack_info")
+
+        fields: dict = {
+            "threads_head": elf.get_struct_member_offset("z_kernel", "threads"),
+            "thread_next": elf.get_struct_member_offset("k_thread", "next_thread"),
+            "stack_start": stack_info + elf.get_struct_member_offset("_thread_stack_info", "start"),
+            "stack_size": stack_info + elf.get_struct_member_offset("_thread_stack_info", "size"),
         }
 
-        self._offsets["thread_info"] = {
-            "stack_start": self._offsets["k_thread"]["stack_info"]
-            + self._elf_inspector.get_struct_member_offset("_thread_stack_info", "start"),
-            "stack_size": self._offsets["k_thread"]["stack_info"]
-            + self._elf_inspector.get_struct_member_offset("_thread_stack_info", "size"),
-            "stack_delta": self._offsets["k_thread"]["stack_info"]
-            + self._elf_inspector.get_struct_member_offset("_thread_stack_info", "delta"),
-        }
-
-        # Known to be only one (at least, expected)
-        self._kernel_base_address = self._elf_inspector.get_symbol_info("_kernel", info="address")[
-            0
-        ]
-        self._threads_address = self._kernel_base_address + self._offsets["kernel"]["threads"]
-
-        self.idle_threads_address = self._elf_inspector.get_symbol_info(
-            "z_idle_threads", "address"
-        )[0]
-
-        try:
-            self._offsets["k_thread"]["name"] = self._elf_inspector.get_struct_member_offset(
-                "k_thread", "name"
-            )
-        except LookupError:
+        if (extras := self._try_resolve_thread_name()) is not None:
+            fields.update(extras)
+        else:
             self.has_names = False
 
-        try:
-            self._offsets["kernel"]["usage"] = self._elf_inspector.get_struct_member_offset(
-                "z_kernel", "usage"
-            )
-            self._offsets["thread_info"].update(
-                {
-                    "usage_base": self._offsets["k_thread"]["base"]
-                    + self._elf_inspector.get_struct_member_offset("_thread_base", "usage")
-                }
-            )
-            self._cpu_usage_address = self._kernel_base_address + self._offsets["kernel"]["usage"]
-            self._m_scraper.begin_batch()
-            self.init_cpu_cycles = self._m_scraper.read64(self._cpu_usage_address)[0]
-            self._m_scraper.end_batch()
-            self.last_cpu_delta = self.init_cpu_cycles
-            self.last_cpu_cycles = self.init_cpu_cycles
-            self.last_thread_cycles = {}
-        except LookupError:
+        if (extras := self._try_resolve_usage()) is not None:
+            fields.update(extras)
+        else:
             self.has_usage = False
 
-        try:
-            self._offsets["thread_info"]["usage"] = self._offsets["thread_info"][
-                "usage_base"
-            ] + self._elf_inspector.get_struct_member_offset("k_cycle_stats", "total")
-            self._offsets["thread_info"]["longest_window"] = self._offsets["thread_info"][
-                "usage_base"
-            ] + self._elf_inspector.get_struct_member_offset("k_cycle_stats", "longest")
+        if (extras := self._try_resolve_heaps()) is not None:
+            fields.update(extras)
+        else:
+            self.has_heaps = False
 
-            self._offsets["thread_info"]["amount_windows"] = self._offsets["thread_info"][
-                "usage_base"
-            ] + self._elf_inspector.get_struct_member_offset("k_cycle_stats", "num_windows")
+        return KernelLayout(**fields)
+
+    def _try_resolve_thread_name(self) -> dict | None:
+        try:
+            return {"thread_name": self._elf_inspector.get_struct_member_offset("k_thread", "name")}
         except LookupError:
-            self.has_extra_info = False
+            return None
 
+    def _try_resolve_usage(self) -> dict | None:
+        elf = self._elf_inspector
         try:
-            self._offsets["heap_info"] = {
-                "z_heap_base": self._elf_inspector.get_struct_member_offset("k_heap", "heap")
-                + self._elf_inspector.get_struct_member_offset("sys_heap", "heap"),
-                "free_bytes": self._elf_inspector.get_struct_member_offset("z_heap", "free_bytes"),
-                "allocated_bytes": self._elf_inspector.get_struct_member_offset(
-                    "z_heap", "allocated_bytes"
-                ),
-                "max_allocated_bytes": self._elf_inspector.get_struct_member_offset(
+            cpu_usage = elf.get_struct_member_offset("z_kernel", "usage")
+            usage_base = elf.get_struct_member_offset(
+                "k_thread", "base"
+            ) + elf.get_struct_member_offset("_thread_base", "usage")
+            thread_usage = usage_base + elf.get_struct_member_offset("k_cycle_stats", "total")
+        except LookupError:
+            return None
+        return {"cpu_usage": cpu_usage, "thread_usage": thread_usage}
+
+    def _try_resolve_heaps(self) -> dict | None:
+        elf = self._elf_inspector
+        try:
+            return {
+                "heap_free_bytes": elf.get_struct_member_offset("z_heap", "free_bytes"),
+                "heap_allocated_bytes": elf.get_struct_member_offset("z_heap", "allocated_bytes"),
+                "heap_max_allocated_bytes": elf.get_struct_member_offset(
                     "z_heap", "max_allocated_bytes"
                 ),
-                "end_chunk": self._elf_inspector.get_struct_member_offset("z_heap", "end_chunk"),
+                "heap_end_chunk": elf.get_struct_member_offset("z_heap", "end_chunk"),
             }
-
         except LookupError:
+            return None
+
+    def _resolve_addresses(self) -> None:
+        elf = self._elf_inspector
+        self._kernel_base_address = elf.get_symbol_info("_kernel", "address")[0]
+        self._threads_address = self._kernel_base_address + self._layout.threads_head
+        self.idle_threads_address = elf.get_symbol_info("z_idle_threads", "address")[0]
+        if self.has_usage:
+            self._cpu_usage_address = self._kernel_base_address + self._layout.cpu_usage
+
+    def _baseline_cpu_cycles(self) -> None:
+        """Read the initial CPU cycle counter so the first polling delta has an anchor."""
+        self._m_scraper.begin_batch()
+        self.init_cpu_cycles = self._m_scraper.read64(self._cpu_usage_address)[0]
+        self._m_scraper.end_batch()
+        self.last_cpu_delta = self.init_cpu_cycles
+        self.last_cpu_cycles = self.init_cpu_cycles
+        self.last_thread_cycles: dict = {}
+
+    def _discover_heap_addresses(self) -> None:
+        """Locate every ``k_heap`` global and store its address(es). Disables heaps if none."""
+        elf = self._elf_inspector
+        names = elf.find_struct_variable_names("k_heap") or []
+        if not names:
             self.has_heaps = False
             return
-
-        all_heaps = self._elf_inspector.find_struct_variable_names("k_heap")
-
-        if all_heaps is None or len(all_heaps) == 0:
-            self.has_heaps = False
-            return
-
-        self._k_heap_addresses = {}
+        self._k_heap_addresses = {n: elf.get_symbol_info(n, "address") for n in names}
         self.extra_info_heap_address: int | None = None
-        for heap in all_heaps:
-            self._k_heap_addresses[heap] = self._elf_inspector.get_symbol_info(heap, "address")
 
     def __enter__(self):
         self._m_scraper.__enter__()
@@ -190,7 +183,7 @@ class ZScraper:
             self._m_scraper,
             self._elf_inspector,
             self._threads_address,
-            self._offsets,
+            self._layout,
             self._endianess,
             self.has_names,
             self._MAX_THREADS,
@@ -202,7 +195,7 @@ class ZScraper:
         return walk_heap_fragmentation(
             self._m_scraper,
             z_heap_addr,
-            self._offsets["heap_info"]["end_chunk"],
+            self._layout.heap_end_chunk,
         )
 
     def reset_thread_pool(self):
@@ -320,7 +313,7 @@ class ZScraper:
                     if self.has_usage:
                         try:
                             thread_usage = self._m_scraper.read64(
-                                thread_info.address + self._offsets["thread_info"]["usage"]
+                                thread_info.address + self._layout.thread_usage
                             )[0]
                         except Exception as e:
                             raise RuntimeError(
@@ -417,14 +410,13 @@ class ZScraper:
                             try:
                                 heap_address_val = self._m_scraper.read32(heap_address)[0]
                                 free_bytes = self._m_scraper.read32(
-                                    heap_address_val + self._offsets["heap_info"]["free_bytes"]
+                                    heap_address_val + self._layout.heap_free_bytes
                                 )[0]
                                 allocated_bytes = self._m_scraper.read32(
-                                    heap_address_val + self._offsets["heap_info"]["allocated_bytes"]
+                                    heap_address_val + self._layout.heap_allocated_bytes
                                 )[0]
                                 max_allocated_bytes = self._m_scraper.read32(
-                                    heap_address_val
-                                    + self._offsets["heap_info"]["max_allocated_bytes"]
+                                    heap_address_val + self._layout.heap_max_allocated_bytes
                                 )[0]
                             except Exception as e:
                                 data_queue.put(

--- a/src/snapshot.py
+++ b/src/snapshot.py
@@ -7,47 +7,14 @@ Headless recording and single-frame JSON snapshot helpers backing the
 ``--snapshot``, ``--replay``, and ``--once --json`` CLI modes.
 """
 
+import dataclasses
 import queue
 import threading
 import time
 
-from backend.base import AbstractScraper, HeapInfo, ThreadInfo, ThreadRuntime
+from backend.base import AbstractScraper
 from backend.recording import RecordingScraper
 from orchestrator import ZScraper
-
-
-def _runtime_to_dict(runtime: ThreadRuntime) -> dict:
-    return {
-        "cpu": runtime.cpu,
-        "cpu_normalized": runtime.cpu_normalized,
-        "active": runtime.active,
-        "stack_watermark": runtime.stack_watermark,
-        "stack_watermark_percent": runtime.stack_watermark_percent,
-    }
-
-
-def _thread_to_dict(thread: ThreadInfo) -> dict:
-    out: dict = {
-        "name": thread.name,
-        "address": thread.address,
-        "stack_start": thread.stack_start,
-        "stack_size": thread.stack_size,
-    }
-    if thread.runtime is not None:
-        out["runtime"] = _runtime_to_dict(thread.runtime)
-    return out
-
-
-def _heap_to_dict(heap: HeapInfo) -> dict:
-    return {
-        "name": heap.name,
-        "address": heap.address,
-        "free_bytes": heap.free_bytes,
-        "allocated_bytes": heap.allocated_bytes,
-        "max_allocated_bytes": heap.max_allocated_bytes,
-        "usage_percent": heap.usage_percent,
-        "chunks": heap.chunks,
-    }
 
 
 def serialize_frame(frame: dict) -> dict:
@@ -57,9 +24,9 @@ def serialize_frame(frame: dict) -> dict:
     """
     out: dict = {}
     if "threads" in frame:
-        out["threads"] = [_thread_to_dict(t) for t in frame["threads"]]
+        out["threads"] = [dataclasses.asdict(t) for t in frame["threads"]]
     if "heaps" in frame:
-        out["heaps"] = [_heap_to_dict(h) for h in frame["heaps"]]
+        out["heaps"] = [dataclasses.asdict(h) for h in frame["heaps"]]
     return out
 
 

--- a/src/snapshot.py
+++ b/src/snapshot.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Headless recording and single-frame JSON snapshot helpers backing the
+``--snapshot``, ``--replay``, and ``--once --json`` CLI modes.
+"""
+
+import queue
+import threading
+import time
+
+from backend.base import AbstractScraper, HeapInfo, ThreadInfo, ThreadRuntime
+from backend.recording import RecordingScraper
+from orchestrator import ZScraper
+
+
+def _runtime_to_dict(runtime: ThreadRuntime) -> dict:
+    return {
+        "cpu": runtime.cpu,
+        "cpu_normalized": runtime.cpu_normalized,
+        "active": runtime.active,
+        "stack_watermark": runtime.stack_watermark,
+        "stack_watermark_percent": runtime.stack_watermark_percent,
+    }
+
+
+def _thread_to_dict(thread: ThreadInfo) -> dict:
+    out: dict = {
+        "name": thread.name,
+        "address": thread.address,
+        "stack_start": thread.stack_start,
+        "stack_size": thread.stack_size,
+    }
+    if thread.runtime is not None:
+        out["runtime"] = _runtime_to_dict(thread.runtime)
+    return out
+
+
+def _heap_to_dict(heap: HeapInfo) -> dict:
+    return {
+        "name": heap.name,
+        "address": heap.address,
+        "free_bytes": heap.free_bytes,
+        "allocated_bytes": heap.allocated_bytes,
+        "max_allocated_bytes": heap.max_allocated_bytes,
+        "usage_percent": heap.usage_percent,
+        "chunks": heap.chunks,
+    }
+
+
+def serialize_frame(frame: dict) -> dict:
+    """
+    Convert a polling-thread frame dict (carrying ThreadInfo and HeapInfo
+    dataclasses) into a JSON-serializable plain-dict shape.
+    """
+    out: dict = {}
+    if "threads" in frame:
+        out["threads"] = [_thread_to_dict(t) for t in frame["threads"]]
+    if "heaps" in frame:
+        out["heaps"] = [_heap_to_dict(h) for h in frame["heaps"]]
+    return out
+
+
+def dump_single_frame(
+    backend: AbstractScraper,
+    elf_path,
+    period: float = 0.1,
+    timeout: float = 5.0,
+) -> dict:
+    """
+    Capture the first valid polling frame from ``backend``. Raises
+    ``RuntimeError`` on a fatal scraper error emitted by the polling thread,
+    and ``TimeoutError`` if no valid frame arrives within ``timeout`` seconds.
+    """
+    with backend:
+        scraper = ZScraper(backend, elf_path)
+        scraper.update_available_threads()
+        scraper.reset_thread_pool()
+        data_queue: queue.Queue = queue.Queue()
+        stop = threading.Event()
+        scraper.start_polling_thread(data_queue, stop, period)
+        deadline = time.monotonic() + timeout
+        try:
+            while time.monotonic() < deadline:
+                try:
+                    frame = data_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                if "fatal_error" in frame:
+                    raise RuntimeError(frame["fatal_error"])
+                if "threads" in frame:
+                    return frame
+            raise TimeoutError(f"No valid frame within {timeout} seconds")
+        finally:
+            stop.set()
+            scraper.finish_polling_thread()
+
+
+def record_session(
+    backend: AbstractScraper,
+    elf_path,
+    out_path,
+    duration: float | None = None,
+    frames: int | None = None,
+    period: float = 0.1,
+) -> int:
+    """
+    Record a polling session to ``out_path``. Bounded by either ``duration``
+    (wall-clock seconds) or ``frames`` (count of valid data frames); at
+    least one must be provided. Returns the number of data frames captured.
+    """
+    if duration is None and frames is None:
+        raise ValueError("record_session requires either duration or frames bound")
+
+    recorder = RecordingScraper(backend, out_path)
+    with recorder:
+        scraper = ZScraper(recorder, elf_path)
+        scraper.update_available_threads()
+        scraper.reset_thread_pool()
+        data_queue: queue.Queue = queue.Queue()
+        stop = threading.Event()
+        scraper.start_polling_thread(data_queue, stop, period)
+
+        captured = 0
+        start = time.monotonic()
+        try:
+            while not stop.is_set():
+                try:
+                    frame = data_queue.get(timeout=0.1)
+                except queue.Empty:
+                    pass
+                else:
+                    if "threads" in frame:
+                        captured += 1
+                        if frames is not None and captured >= frames:
+                            break
+                if duration is not None and (time.monotonic() - start) >= duration:
+                    break
+        finally:
+            stop.set()
+            scraper.finish_polling_thread()
+        return captured

--- a/src/snapshot.py
+++ b/src/snapshot.py
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Headless recording and single-frame JSON snapshot helpers backing the
-``--snapshot``, ``--replay``, and ``--once --json`` CLI modes.
-"""
+"""Headless recording, replay, and single-frame helpers used by the CLI commands."""
 
 import dataclasses
 import queue
@@ -18,10 +15,7 @@ from orchestrator import ZScraper
 
 
 def serialize_frame(frame: dict) -> dict:
-    """
-    Convert a polling-thread frame dict (carrying ThreadInfo and HeapInfo
-    dataclasses) into a JSON-serializable plain-dict shape.
-    """
+    """Convert a polling frame's dataclasses into a JSON-serializable dict."""
     out: dict = {}
     if "threads" in frame:
         out["threads"] = [dataclasses.asdict(t) for t in frame["threads"]]
@@ -38,12 +32,10 @@ def dump_single_frame(
     timeout: float | None = None,
 ) -> dict:
     """
-    Capture the Nth valid polling frame from ``backend`` (1-indexed). Skips
-    ``frame - 1`` valid data frames before returning. Raises ``ValueError``
-    when ``frame < 1``, ``RuntimeError`` on a fatal scraper error or when the
-    recording exhausts before reaching frame N, and ``TimeoutError`` if no
-    frame arrives within ``timeout`` seconds. ``timeout`` defaults to a value
-    proportional to ``frame * period``.
+    Return the Nth valid polling frame (1-indexed; default 1).
+    Raises ``ValueError`` for ``frame < 1``, ``RuntimeError`` on fatal scraper
+    error or recording exhaustion, ``TimeoutError`` past ``timeout`` seconds.
+    ``timeout`` defaults to ``max(5.0, frame * max(period, 0.1) * 5.0)``.
     """
     if frame < 1:
         raise ValueError("frame must be >= 1")
@@ -83,10 +75,8 @@ def dump_single_frame(
 
 def _configure_heap_detail(scraper: ZScraper, recorder: AbstractScraper, heap_name: str) -> None:
     """
-    Resolve ``heap_name`` to the live heap struct pointer and set
-    ``scraper.extra_info_heap_address`` so every polled frame captures
-    fragmentation data for that heap. Raises ``ValueError`` when the ELF
-    exposes no heap symbols or the requested name is unknown.
+    Set ``scraper.extra_info_heap_address`` from the named ``k_heap`` global.
+    Raises ``ValueError`` when the ELF has no heaps or ``heap_name`` is unknown.
     """
     if not scraper.has_heaps or not getattr(scraper, "_k_heap_addresses", None):
         raise ValueError("This ELF exposes no k_heap symbols; --heap-detail unavailable.")
@@ -114,12 +104,9 @@ def record_session(
     heap_detail: str | None = None,
 ) -> int:
     """
-    Record a polling session to ``out_path``. Bounded by either ``duration``
-    (wall-clock seconds) or ``frames`` (count of valid data frames); at
-    least one must be provided. When ``heap_detail`` names a k_heap symbol
-    resolved from the ELF, the session also captures per-frame
-    fragmentation reads for that heap. Returns the number of data frames
-    captured.
+    Record a polling session to ``out_path``. Requires one of ``duration``
+    (seconds) or ``frames`` (count). ``heap_detail`` names a ``k_heap``
+    global to capture per-frame fragmentation for. Returns frame count.
     """
     if duration is None and frames is None:
         raise ValueError("record_session requires either duration or frames bound")

--- a/src/snapshot.py
+++ b/src/snapshot.py
@@ -67,13 +67,22 @@ def dump_single_frame(
     backend: AbstractScraper,
     elf_path,
     period: float = 0.1,
-    timeout: float = 5.0,
+    frame: int = 1,
+    timeout: float | None = None,
 ) -> dict:
     """
-    Capture the first valid polling frame from ``backend``. Raises
-    ``RuntimeError`` on a fatal scraper error emitted by the polling thread,
-    and ``TimeoutError`` if no valid frame arrives within ``timeout`` seconds.
+    Capture the Nth valid polling frame from ``backend`` (1-indexed). Skips
+    ``frame - 1`` valid data frames before returning. Raises ``ValueError``
+    when ``frame < 1``, ``RuntimeError`` on a fatal scraper error or when the
+    recording exhausts before reaching frame N, and ``TimeoutError`` if no
+    frame arrives within ``timeout`` seconds. ``timeout`` defaults to a value
+    proportional to ``frame * period``.
     """
+    if frame < 1:
+        raise ValueError("frame must be >= 1")
+    if timeout is None:
+        timeout = max(5.0, frame * max(period, 0.1) * 5.0)
+
     with backend:
         scraper = ZScraper(backend, elf_path)
         scraper.update_available_threads()
@@ -82,20 +91,50 @@ def dump_single_frame(
         stop = threading.Event()
         scraper.start_polling_thread(data_queue, stop, period)
         deadline = time.monotonic() + timeout
+        seen = 0
         try:
             while time.monotonic() < deadline:
                 try:
-                    frame = data_queue.get(timeout=0.1)
+                    frame_data = data_queue.get(timeout=0.1)
                 except queue.Empty:
                     continue
-                if "fatal_error" in frame:
-                    raise RuntimeError(frame["fatal_error"])
-                if "threads" in frame:
-                    return frame
-            raise TimeoutError(f"No valid frame within {timeout} seconds")
+                if "fatal_error" in frame_data:
+                    raise RuntimeError(frame_data["fatal_error"])
+                if "replay_complete" in frame_data:
+                    raise RuntimeError(
+                        f"Recording has only {seen} frames; --frame {frame} out of range."
+                    )
+                if "threads" in frame_data:
+                    seen += 1
+                    if seen >= frame:
+                        return frame_data
+            raise TimeoutError(f"No frame {frame} within {timeout} seconds")
         finally:
             stop.set()
             scraper.finish_polling_thread()
+
+
+def _configure_heap_detail(scraper: ZScraper, recorder: AbstractScraper, heap_name: str) -> None:
+    """
+    Resolve ``heap_name`` to the live heap struct pointer and set
+    ``scraper.extra_info_heap_address`` so every polled frame captures
+    fragmentation data for that heap. Raises ``ValueError`` when the ELF
+    exposes no heap symbols or the requested name is unknown.
+    """
+    if not scraper.has_heaps or not getattr(scraper, "_k_heap_addresses", None):
+        raise ValueError("This ELF exposes no k_heap symbols; --heap-detail unavailable.")
+
+    if heap_name not in scraper._k_heap_addresses:
+        available = ", ".join(sorted(scraper._k_heap_addresses.keys()))
+        raise ValueError(f"Heap {heap_name!r} not found. Available heaps: {available}.")
+
+    symbol_addrs = scraper._k_heap_addresses[heap_name]
+    recorder.begin_batch()
+    try:
+        heap_struct_ptr = recorder.read32(symbol_addrs[0])[0]
+    finally:
+        recorder.end_batch()
+    scraper.extra_info_heap_address = heap_struct_ptr
 
 
 def record_session(
@@ -105,11 +144,15 @@ def record_session(
     duration: float | None = None,
     frames: int | None = None,
     period: float = 0.1,
+    heap_detail: str | None = None,
 ) -> int:
     """
     Record a polling session to ``out_path``. Bounded by either ``duration``
     (wall-clock seconds) or ``frames`` (count of valid data frames); at
-    least one must be provided. Returns the number of data frames captured.
+    least one must be provided. When ``heap_detail`` names a k_heap symbol
+    resolved from the ELF, the session also captures per-frame
+    fragmentation reads for that heap. Returns the number of data frames
+    captured.
     """
     if duration is None and frames is None:
         raise ValueError("record_session requires either duration or frames bound")
@@ -119,6 +162,10 @@ def record_session(
         scraper = ZScraper(recorder, elf_path)
         scraper.update_available_threads()
         scraper.reset_thread_pool()
+
+        if heap_detail is not None:
+            _configure_heap_detail(scraper, recorder, heap_detail)
+
         data_queue: queue.Queue = queue.Queue()
         stop = threading.Event()
         scraper.start_polling_thread(data_queue, stop, period)

--- a/src/zview_cli.py
+++ b/src/zview_cli.py
@@ -1,69 +1,160 @@
 import argparse
 import curses
+import json
+import sys
 
+from backend.base import AbstractScraper
 from backend.gdb import GDBScraper
 from backend.jlink import JLinkScraper
 from backend.pyocd import PyOCDScraper
+from backend.replay import ReplayScraper
 from frontend.zview_tui import tui_run
 from logging_setup import configure as configure_logging
 from orchestrator import ZScraper
+from snapshot import dump_single_frame, record_session, serialize_frame
+
+AVAILABLE_RUNNERS = ("gdb", "jlink", "pyocd")
 
 
-def main():
-    configure_logging()
-
-    available_runners = ["gdb", "jlink", "pyocd"]
-
-    arg_parser = argparse.ArgumentParser(
-        description="ZView - A real-time thread viewer for Zephyr RTOS."
-    )
-    arg_parser.add_argument(
-        "-e",
-        "--elf-file",
-        required=True,
-        help="Path to the application's .elf firmware file.",
-    )
-    arg_parser.add_argument(
-        "-r",
-        "--runner",
-        required=True,
-        choices=available_runners,
-        help="Runner to start analysis with.",
-    )
-    arg_parser.add_argument(
-        "-t",
-        "--runner-target",
-        required=True,
-        help="Descriptor name for the target MCU on the chosen runner",
-    )
-    arg_parser.add_argument(
-        "--period",
-        default=0.10,
-        type=float,
-        help="Minimum period to update system information.",
-    )
-
-    args = arg_parser.parse_args()
+def _build_backend(args) -> AbstractScraper:
+    if args.replay:
+        return ReplayScraper(args.replay)
 
     scraper_map = {
         "gdb": GDBScraper,
         "jlink": JLinkScraper,
         "pyocd": PyOCDScraper,
     }
-
     scraper_cls = scraper_map.get(args.runner, PyOCDScraper)
+    return scraper_cls(args.runner_target)
 
-    with scraper_cls(args.runner_target) as meta_scraper:
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="ZView - A real-time thread viewer for Zephyr RTOS."
+    )
+    parser.add_argument(
+        "-e",
+        "--elf-file",
+        required=True,
+        help="Path to the application's .elf firmware file.",
+    )
+    parser.add_argument(
+        "-r",
+        "--runner",
+        choices=AVAILABLE_RUNNERS,
+        default=None,
+        help="Runner to start analysis with (required unless --replay is given).",
+    )
+    parser.add_argument(
+        "-t",
+        "--runner-target",
+        default=None,
+        help="Descriptor name for the target MCU on the chosen runner.",
+    )
+    parser.add_argument(
+        "--period",
+        default=0.10,
+        type=float,
+        help="Minimum period to update system information.",
+    )
+    parser.add_argument(
+        "--replay",
+        metavar="PATH",
+        help="Replay a .ndjson.gz recording instead of attaching to a live target.",
+    )
+    parser.add_argument(
+        "--snapshot",
+        metavar="PATH",
+        help="Record a live polling session to a .ndjson.gz file and exit.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        help="Snapshot upper bound in seconds (with --snapshot).",
+    )
+    parser.add_argument(
+        "--frames",
+        type=int,
+        help="Snapshot upper bound in data frames (with --snapshot).",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Emit a single polling frame and exit (no TUI).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="With --once, emit the frame as JSON to stdout.",
+    )
+
+    args = parser.parse_args()
+
+    if not args.replay:
+        if not args.runner:
+            parser.error("-r/--runner is required unless --replay is given.")
+        if not args.runner_target:
+            parser.error("-t/--runner-target is required unless --replay is given.")
+
+    if args.snapshot and args.replay:
+        parser.error("--snapshot and --replay are mutually exclusive.")
+    if args.snapshot and args.once:
+        parser.error("--snapshot and --once are mutually exclusive.")
+    if args.snapshot and args.duration is None and args.frames is None:
+        parser.error("--snapshot requires --duration or --frames.")
+    if args.json and not args.once:
+        parser.error("--json only applies to --once.")
+
+    return args
+
+
+def main() -> int:
+    configure_logging()
+    args = _parse_args()
+
+    backend = _build_backend(args)
+
+    if args.snapshot:
+        captured = record_session(
+            backend,
+            args.elf_file,
+            args.snapshot,
+            duration=args.duration,
+            frames=args.frames,
+            period=args.period,
+        )
+        print(f"Recorded {captured} frames to {args.snapshot}")
+        return 0
+
+    if args.once:
+        frame = dump_single_frame(backend, args.elf_file, period=args.period)
+        if args.json:
+            print(json.dumps(serialize_frame(frame)))
+        else:
+            for t in frame.get("threads", []):
+                wm = t.runtime.stack_watermark if t.runtime else "-"
+                print(f"{t.name:30s} stack={t.stack_size:>6}  watermark={wm}")
+            for h in frame.get("heaps", []):
+                print(
+                    f"heap {h.name:20s} free={h.free_bytes} "
+                    f"alloc={h.allocated_bytes} max={h.max_allocated_bytes}"
+                )
+        return 0
+
+    with backend as meta_scraper:
         z_scraper = ZScraper(meta_scraper, args.elf_file)
         if not z_scraper.has_names:
-            print("NO thread names available (CONFIG_THREAD_NAME=n)")
+            print("NO thread names available (CONFIG_THREAD_NAME=n)", file=sys.stderr)
         if not z_scraper.has_usage:
-            print("NO cpu stats available (CONFIG_THREAD_RUNTIME_STATS=n)")
+            print("NO cpu stats available (CONFIG_THREAD_RUNTIME_STATS=n)", file=sys.stderr)
         if not z_scraper.has_heaps:
-            print("NO heap stats available (CONFIG_SYS_HEAP_RUNTIME_STATS=n)")
+            print("NO heap stats available (CONFIG_SYS_HEAP_RUNTIME_STATS=n)", file=sys.stderr)
 
         curses.wrapper(tui_run, z_scraper, args.period)
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/zview_cli.py
+++ b/src/zview_cli.py
@@ -3,7 +3,6 @@ import curses
 import json
 import sys
 
-from backend.base import AbstractScraper
 from backend.gdb import GDBScraper
 from backend.jlink import JLinkScraper
 from backend.pyocd import PyOCDScraper
@@ -14,146 +13,250 @@ from orchestrator import ZScraper
 from snapshot import dump_single_frame, record_session, serialize_frame
 
 AVAILABLE_RUNNERS = ("gdb", "jlink", "pyocd")
+KNOWN_COMMANDS = ("live", "record", "replay", "dump")
 
 
-def _build_backend(args) -> AbstractScraper:
-    if args.replay:
-        return ReplayScraper(args.replay)
-
-    scraper_map = {
-        "gdb": GDBScraper,
-        "jlink": JLinkScraper,
-        "pyocd": PyOCDScraper,
-    }
-    scraper_cls = scraper_map.get(args.runner, PyOCDScraper)
-    return scraper_cls(args.runner_target)
+def _normalize_argv(argv: list[str]) -> list[str]:
+    """Splice the implicit ``live`` command when zview is invoked without one."""
+    if not argv:
+        return argv
+    first = argv[0]
+    if first in KNOWN_COMMANDS or first in ("-h", "--help"):
+        return argv
+    return ["live", *argv]
 
 
-def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="ZView - A real-time thread viewer for Zephyr RTOS."
-    )
+def _add_elf(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "-e",
         "--elf-file",
         required=True,
         help="Path to the application's .elf firmware file.",
     )
+
+
+def _add_live_target(parser: argparse.ArgumentParser, *, required: bool = True) -> None:
     parser.add_argument(
         "-r",
         "--runner",
         choices=AVAILABLE_RUNNERS,
+        required=required,
         default=None,
-        help="Runner to start analysis with (required unless --replay is given).",
+        help="Debug runner to attach to the live target.",
     )
     parser.add_argument(
         "-t",
         "--runner-target",
+        required=required,
         default=None,
-        help="Descriptor name for the target MCU on the chosen runner.",
+        help="MCU descriptor for the chosen runner.",
     )
+
+
+def _add_period(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--period",
+        type=float,
         default=0.10,
-        type=float,
-        help="Minimum period to update system information.",
+        help="Minimum polling period in seconds (default: 0.10).",
     )
-    parser.add_argument(
-        "--replay",
-        metavar="PATH",
-        help="Replay a .ndjson.gz recording instead of attaching to a live target.",
+
+
+def _build_parser(
+    prog: str = "zview",
+    subcommand_epilogs: dict[str, str] | None = None,
+) -> argparse.ArgumentParser:
+    epilogs = subcommand_epilogs or {}
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="ZView - Zephyr RTOS runtime visualizer over SWD.",
+        epilog=f"Run `{prog} <command> --help` for command-specific options.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument(
-        "--snapshot",
-        metavar="PATH",
-        help="Record a live polling session to a .ndjson.gz file and exit.",
+    sub = parser.add_subparsers(dest="cmd", metavar="COMMAND", required=True)
+
+    def _sub(name: str, summary: str) -> argparse.ArgumentParser:
+        return sub.add_parser(
+            name,
+            help=summary,
+            epilog=epilogs.get(name),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+
+    p_live = _sub("live", "Attach to a probe and render the TUI (default).")
+    _add_elf(p_live)
+    _add_live_target(p_live)
+    _add_period(p_live)
+
+    p_record = _sub("record", "Capture a live session to a .ndjson.gz recording file.")
+    _add_elf(p_record)
+    _add_live_target(p_record)
+    p_record.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        metavar="FILE",
+        help="Recording target path (.ndjson.gz).",
     )
-    parser.add_argument(
-        "--duration",
-        type=float,
-        help="Snapshot upper bound in seconds (with --snapshot).",
+    bound = p_record.add_mutually_exclusive_group(required=True)
+    bound.add_argument("--duration", type=float, help="Recording bound, in seconds.")
+    bound.add_argument("--frames", type=int, help="Recording bound, in data frames.")
+    p_record.add_argument(
+        "--heap",
+        metavar="NAME",
+        help="Capture per-frame fragmentation reads for the named k_heap variable.",
     )
-    parser.add_argument(
-        "--frames",
-        type=int,
-        help="Snapshot upper bound in data frames (with --snapshot).",
+    _add_period(p_record)
+
+    p_replay = _sub("replay", "Render the TUI from a recording file.")
+    _add_elf(p_replay)
+    p_replay.add_argument(
+        "-i",
+        "--input",
+        required=True,
+        metavar="FILE",
+        help="Recording source path (.ndjson.gz).",
     )
-    parser.add_argument(
-        "--once",
+    p_replay.add_argument(
+        "--no-pacing",
         action="store_true",
-        help="Emit a single polling frame and exit (no TUI).",
+        help="Drain the recording as fast as possible instead of honoring its wall-clock cadence.",
     )
-    parser.add_argument(
+
+    p_dump = _sub("dump", "Capture a single polling frame and exit (no TUI).")
+    _add_elf(p_dump)
+    _add_live_target(p_dump, required=False)
+    p_dump.add_argument(
+        "-i",
+        "--input",
+        metavar="FILE",
+        help="Replay source path (.ndjson.gz). Mutually exclusive with --runner/--runner-target.",
+    )
+    p_dump.add_argument(
+        "--frame",
+        type=int,
+        default=1,
+        help="Which polling frame to dump (1-indexed). Default: 1.",
+    )
+    p_dump.add_argument(
         "--json",
         action="store_true",
-        help="With --once, emit the frame as JSON to stdout.",
+        help="Emit the frame as JSON on stdout.",
     )
+    _add_period(p_dump)
 
-    args = parser.parse_args()
+    return parser
 
-    if not args.replay:
-        if not args.runner:
-            parser.error("-r/--runner is required unless --replay is given.")
-        if not args.runner_target:
-            parser.error("-t/--runner-target is required unless --replay is given.")
 
-    if args.snapshot and args.replay:
-        parser.error("--snapshot and --replay are mutually exclusive.")
-    if args.snapshot and args.once:
-        parser.error("--snapshot and --once are mutually exclusive.")
-    if args.snapshot and args.duration is None and args.frames is None:
-        parser.error("--snapshot requires --duration or --frames.")
-    if args.json and not args.once:
-        parser.error("--json only applies to --once.")
+def _parse_args(
+    argv: list[str],
+    prog: str = "zview",
+    subcommand_epilogs: dict[str, str] | None = None,
+) -> argparse.Namespace:
+    parser = _build_parser(prog=prog, subcommand_epilogs=subcommand_epilogs)
+    args = parser.parse_args(argv)
+
+    if args.cmd == "dump":
+        if args.input and (args.runner or args.runner_target):
+            parser.error("dump: --input is mutually exclusive with --runner/--runner-target.")
+        if not args.input and not (args.runner and args.runner_target):
+            parser.error("dump: requires either --input FILE or both --runner and --runner-target.")
+        if args.frame < 1:
+            parser.error("dump: --frame must be >= 1.")
 
     return args
 
 
-def main() -> int:
-    configure_logging()
-    args = _parse_args()
+def _build_live_backend(args):
+    scraper_map = {
+        "gdb": GDBScraper,
+        "jlink": JLinkScraper,
+        "pyocd": PyOCDScraper,
+    }
+    cls = scraper_map.get(args.runner, PyOCDScraper)
+    return cls(args.runner_target)
 
-    backend = _build_backend(args)
 
-    if args.snapshot:
-        captured = record_session(
-            backend,
-            args.elf_file,
-            args.snapshot,
-            duration=args.duration,
-            frames=args.frames,
-            period=args.period,
-        )
-        print(f"Recorded {captured} frames to {args.snapshot}")
-        return 0
-
-    if args.once:
-        frame = dump_single_frame(backend, args.elf_file, period=args.period)
-        if args.json:
-            print(json.dumps(serialize_frame(frame)))
-        else:
-            for t in frame.get("threads", []):
-                wm = t.runtime.stack_watermark if t.runtime else "-"
-                print(f"{t.name:30s} stack={t.stack_size:>6}  watermark={wm}")
-            for h in frame.get("heaps", []):
-                print(
-                    f"heap {h.name:20s} free={h.free_bytes} "
-                    f"alloc={h.allocated_bytes} max={h.max_allocated_bytes}"
-                )
-        return 0
-
-    with backend as meta_scraper:
-        z_scraper = ZScraper(meta_scraper, args.elf_file)
-        if not z_scraper.has_names:
+def _do_live(args) -> int:
+    with _build_live_backend(args) as backend:
+        scraper = ZScraper(backend, args.elf_file)
+        if not scraper.has_names:
             print("NO thread names available (CONFIG_THREAD_NAME=n)", file=sys.stderr)
-        if not z_scraper.has_usage:
+        if not scraper.has_usage:
             print("NO cpu stats available (CONFIG_THREAD_RUNTIME_STATS=n)", file=sys.stderr)
-        if not z_scraper.has_heaps:
+        if not scraper.has_heaps:
             print("NO heap stats available (CONFIG_SYS_HEAP_RUNTIME_STATS=n)", file=sys.stderr)
-
-        curses.wrapper(tui_run, z_scraper, args.period)
-
+        curses.wrapper(tui_run, scraper, args.period)
     return 0
+
+
+def _do_record(args) -> int:
+    backend = _build_live_backend(args)
+    captured = record_session(
+        backend,
+        args.elf_file,
+        args.output,
+        duration=args.duration,
+        frames=args.frames,
+        period=args.period,
+        heap_detail=args.heap,
+    )
+    print(f"Recorded {captured} frames to {args.output}")
+    return 0
+
+
+def _do_replay(args) -> int:
+    backend = ReplayScraper(args.input, honor_timing=not args.no_pacing)
+    with backend:
+        scraper = ZScraper(backend, args.elf_file)
+        # Pacing comes from the recording; the polling-thread sleep is just a floor.
+        curses.wrapper(tui_run, scraper, 0.05)
+    return 0
+
+
+def _do_dump(args) -> int:
+    if args.input:
+        backend = ReplayScraper(args.input, honor_timing=False)
+    else:
+        backend = _build_live_backend(args)
+
+    frame = dump_single_frame(
+        backend,
+        args.elf_file,
+        period=args.period,
+        frame=args.frame,
+    )
+    if args.json:
+        print(json.dumps(serialize_frame(frame)))
+    else:
+        for t in frame.get("threads", []):
+            wm = t.runtime.stack_watermark if t.runtime else "-"
+            print(f"thread {t.name:30s} stack={t.stack_size:>6}  watermark={wm}")
+        for h in frame.get("heaps", []):
+            print(
+                f"heap {h.name:20s} free={h.free_bytes} "
+                f"alloc={h.allocated_bytes} max={h.max_allocated_bytes}"
+            )
+    return 0
+
+
+_DISPATCH = {
+    "live": _do_live,
+    "record": _do_record,
+    "replay": _do_replay,
+    "dump": _do_dump,
+}
+
+
+def main(
+    argv: list[str] | None = None,
+    prog: str = "zview",
+    subcommand_epilogs: dict[str, str] | None = None,
+) -> int:
+    configure_logging()
+    raw = sys.argv[1:] if argv is None else argv
+    args = _parse_args(_normalize_argv(raw), prog=prog, subcommand_epilogs=subcommand_epilogs)
+    return _DISPATCH[args.cmd](args)
 
 
 if __name__ == "__main__":

--- a/src/zview_cli.py
+++ b/src/zview_cli.py
@@ -17,7 +17,7 @@ KNOWN_COMMANDS = ("live", "record", "replay", "dump")
 
 
 def _normalize_argv(argv: list[str]) -> list[str]:
-    """Splice the implicit ``live`` command when zview is invoked without one."""
+    """Prepend ``live`` when ``argv`` does not start with a known command."""
     if not argv:
         return argv
     first = argv[0]
@@ -26,11 +26,12 @@ def _normalize_argv(argv: list[str]) -> list[str]:
     return ["live", *argv]
 
 
-def _add_elf(parser: argparse.ArgumentParser) -> None:
+def _add_elf(parser: argparse.ArgumentParser, *, required: bool = True) -> None:
     parser.add_argument(
         "-e",
         "--elf-file",
-        required=True,
+        required=required,
+        default=None,
         help="Path to the application's .elf firmware file.",
     )
 
@@ -62,18 +63,20 @@ def _add_period(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _build_parser(
-    prog: str = "zview",
+def register_commands(
+    sub: argparse._SubParsersAction,
+    *,
+    auto_filled: frozenset[str] = frozenset(),
     subcommand_epilogs: dict[str, str] | None = None,
-) -> argparse.ArgumentParser:
+) -> None:
+    """
+    Add the live/record/replay/dump subparsers to ``sub``.
+    Flag names listed in ``auto_filled`` ({"elf", "target"}) are declared
+    non-required. ``subcommand_epilogs`` maps command name → epilog text.
+    """
     epilogs = subcommand_epilogs or {}
-    parser = argparse.ArgumentParser(
-        prog=prog,
-        description="ZView - Zephyr RTOS runtime visualizer over SWD.",
-        epilog=f"Run `{prog} <command> --help` for command-specific options.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    sub = parser.add_subparsers(dest="cmd", metavar="COMMAND", required=True)
+    elf_required = "elf" not in auto_filled
+    target_required = "target" not in auto_filled
 
     def _sub(name: str, summary: str) -> argparse.ArgumentParser:
         return sub.add_parser(
@@ -84,13 +87,13 @@ def _build_parser(
         )
 
     p_live = _sub("live", "Attach to a probe and render the TUI (default).")
-    _add_elf(p_live)
-    _add_live_target(p_live)
+    _add_elf(p_live, required=elf_required)
+    _add_live_target(p_live, required=target_required)
     _add_period(p_live)
 
     p_record = _sub("record", "Capture a live session to a .ndjson.gz recording file.")
-    _add_elf(p_record)
-    _add_live_target(p_record)
+    _add_elf(p_record, required=elf_required)
+    _add_live_target(p_record, required=target_required)
     p_record.add_argument(
         "-o",
         "--output",
@@ -109,7 +112,7 @@ def _build_parser(
     _add_period(p_record)
 
     p_replay = _sub("replay", "Render the TUI from a recording file.")
-    _add_elf(p_replay)
+    _add_elf(p_replay, required=elf_required)
     p_replay.add_argument(
         "-i",
         "--input",
@@ -124,7 +127,8 @@ def _build_parser(
     )
 
     p_dump = _sub("dump", "Capture a single polling frame and exit (no TUI).")
-    _add_elf(p_dump)
+    _add_elf(p_dump, required=elf_required)
+    # Dump's runner/target are always optional (-i is the alternative source).
     _add_live_target(p_dump, required=False)
     p_dump.add_argument(
         "-i",
@@ -145,6 +149,30 @@ def _build_parser(
     )
     _add_period(p_dump)
 
+
+def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Post-parse cross-flag validation. Calls ``parser.error()`` on failure."""
+    if args.cmd == "dump":
+        if args.input and (args.runner or args.runner_target):
+            parser.error("dump: --input is mutually exclusive with --runner/--runner-target.")
+        if not args.input and not (args.runner and args.runner_target):
+            parser.error("dump: requires either --input FILE or both --runner and --runner-target.")
+        if args.frame < 1:
+            parser.error("dump: --frame must be >= 1.")
+
+
+def _build_parser(
+    prog: str = "zview",
+    subcommand_epilogs: dict[str, str] | None = None,
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="ZView - Zephyr RTOS runtime visualizer over SWD.",
+        epilog=f"Run `{prog} <command> --help` for command-specific options.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", metavar="COMMAND", required=True)
+    register_commands(sub, subcommand_epilogs=subcommand_epilogs)
     return parser
 
 
@@ -155,15 +183,7 @@ def _parse_args(
 ) -> argparse.Namespace:
     parser = _build_parser(prog=prog, subcommand_epilogs=subcommand_epilogs)
     args = parser.parse_args(argv)
-
-    if args.cmd == "dump":
-        if args.input and (args.runner or args.runner_target):
-            parser.error("dump: --input is mutually exclusive with --runner/--runner-target.")
-        if not args.input and not (args.runner and args.runner_target):
-            parser.error("dump: requires either --input FILE or both --runner and --runner-target.")
-        if args.frame < 1:
-            parser.error("dump: --frame must be >= 1.")
-
+    validate_args(parser, args)
     return args
 
 
@@ -248,6 +268,11 @@ _DISPATCH = {
 }
 
 
+def dispatch(args: argparse.Namespace) -> int:
+    """Run the command named by ``args.cmd``."""
+    return _DISPATCH[args.cmd](args)
+
+
 def main(
     argv: list[str] | None = None,
     prog: str = "zview",
@@ -256,7 +281,7 @@ def main(
     configure_logging()
     raw = sys.argv[1:] if argv is None else argv
     args = _parse_args(_normalize_argv(raw), prog=prog, subcommand_epilogs=subcommand_epilogs)
-    return _DISPATCH[args.cmd](args)
+    return dispatch(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-CLI wiring coverage for zview_cli.main: verb dispatch, default-verb splicing,
-flag validation per verb, and stdout/stderr separation for headless modes.
-"""
+"""CLI wiring coverage for zview_cli.main."""
 
 import json
 import sys
@@ -88,7 +85,7 @@ def test_dump_replay_human_readable(monkeypatch, capsys):
 
 
 def test_dump_frame_arg_skips_to_requested_frame(monkeypatch, capsys):
-    """--frame 3 emits a different frame than --frame 1 (CPU deltas accumulate over replay)."""
+    """--frame 3 emits a different frame than --frame 1."""
     rc1, out1, _ = _invoke(
         monkeypatch,
         capsys,
@@ -234,7 +231,7 @@ def test_record_forwards_heap_flag(monkeypatch, capsys, tmp_path):
 
 
 def test_replay_no_pacing_passes_to_scraper(monkeypatch, capsys):
-    """--no-pacing constructs the ReplayScraper with honor_timing=False."""
+    """--no-pacing → ReplayScraper(honor_timing=False)."""
     captured: dict = {}
     real_cls = zview_cli.ReplayScraper
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CLI wiring coverage for zview_cli.main: argparse dispatch, flag validation,
+stdout/stderr separation for headless modes, and --once rendering.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import zview_cli
+
+_TESTS_DIR = Path(__file__).parent
+_FIXTURE = _TESTS_DIR / "fixtures" / "recordings" / "sys_heap_v4.3.ndjson.gz"
+_ELF = _TESTS_DIR / "fixtures" / "zephyr.elf"
+
+
+def _invoke(monkeypatch, capsys, argv: list[str]):
+    """Run zview_cli.main with ``argv``; return (rc, stdout, stderr)."""
+    monkeypatch.setattr(sys, "argv", ["zview", *argv])
+    try:
+        rc = zview_cli.main()
+    except SystemExit as exc:
+        rc = exc.code
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+def test_once_json_stdout_is_valid_json(monkeypatch, capsys):
+    rc, out, _ = _invoke(
+        monkeypatch,
+        capsys,
+        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once", "--json"],
+    )
+    assert rc == 0
+    data = json.loads(out)
+    assert "threads" in data and len(data["threads"]) >= 1
+
+
+def test_once_json_keeps_stdout_clean_of_status_lines(monkeypatch, capsys):
+    rc, out, err = _invoke(
+        monkeypatch,
+        capsys,
+        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once", "--json"],
+    )
+    assert rc == 0
+    # Stdout must contain ONLY the JSON document; any status line on stdout
+    # would both fail json.loads and leak diagnostic strings.
+    stripped = out.strip()
+    assert stripped.startswith("{")
+    assert stripped.endswith("}")
+    assert "Loaded cached ELF" not in out
+    assert "Connected to GDB" not in out
+    # Diagnostic that DID fire must be on stderr.
+    assert "Loaded cached ELF" in err or "Loading ELF" in err
+
+
+def test_once_human_readable_lists_threads(monkeypatch, capsys):
+    rc, out, _ = _invoke(
+        monkeypatch,
+        capsys,
+        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once"],
+    )
+    assert rc == 0
+    for expected_thread in ("stress_id", "idle", "main"):
+        assert expected_thread in out
+    assert "stack=" in out
+    assert "watermark=" in out
+
+
+def test_requires_runner_without_replay(monkeypatch, capsys):
+    rc, _, err = _invoke(monkeypatch, capsys, ["-e", str(_ELF)])
+    assert rc == 2
+    assert "--runner" in err
+
+
+def test_requires_runner_target_without_replay(monkeypatch, capsys):
+    rc, _, err = _invoke(monkeypatch, capsys, ["-e", str(_ELF), "-r", "gdb"])
+    assert rc == 2
+    assert "--runner-target" in err
+
+
+def test_snapshot_and_replay_are_mutually_exclusive(monkeypatch, capsys, tmp_path):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        [
+            "-e",
+            str(_ELF),
+            "--replay",
+            str(_FIXTURE),
+            "--snapshot",
+            str(tmp_path / "x.ndjson.gz"),
+            "--frames",
+            "1",
+        ],
+    )
+    assert rc == 2
+    assert "mutually exclusive" in err
+
+
+def test_snapshot_and_once_are_mutually_exclusive(monkeypatch, capsys, tmp_path):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        [
+            "-e",
+            str(_ELF),
+            "-r",
+            "gdb",
+            "-t",
+            "localhost:1",
+            "--snapshot",
+            str(tmp_path / "x.ndjson.gz"),
+            "--once",
+            "--frames",
+            "1",
+        ],
+    )
+    assert rc == 2
+    assert "mutually exclusive" in err
+
+
+def test_snapshot_requires_duration_or_frames(monkeypatch, capsys, tmp_path):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        [
+            "-e",
+            str(_ELF),
+            "-r",
+            "gdb",
+            "-t",
+            "localhost:1",
+            "--snapshot",
+            str(tmp_path / "x.ndjson.gz"),
+        ],
+    )
+    assert rc == 2
+    assert "--duration" in err or "--frames" in err
+
+
+def test_json_requires_once(monkeypatch, capsys):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--json"],
+    )
+    assert rc == 2
+    assert "--once" in err
+
+
+def test_snapshot_dispatches_with_bound(monkeypatch, capsys, tmp_path):
+    """main() forwards --frames to record_session and reports the captured count."""
+    recorded_calls: list[dict] = []
+
+    def fake_record(backend, elf_path, out_path, duration=None, frames=None, period=0.1):
+        recorded_calls.append(
+            {
+                "out_path": str(out_path),
+                "duration": duration,
+                "frames": frames,
+                "period": period,
+            }
+        )
+        return 7
+
+    monkeypatch.setattr(zview_cli, "record_session", fake_record)
+
+    out_file = tmp_path / "snap.ndjson.gz"
+    rc, out, _ = _invoke(
+        monkeypatch,
+        capsys,
+        [
+            "-e",
+            str(_ELF),
+            "-r",
+            "gdb",
+            "-t",
+            "localhost:1",
+            "--snapshot",
+            str(out_file),
+            "--frames",
+            "5",
+        ],
+    )
+
+    assert rc == 0
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0]["frames"] == 5
+    assert recorded_calls[0]["duration"] is None
+    assert f"Recorded 7 frames to {out_file}" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-CLI wiring coverage for zview_cli.main: argparse dispatch, flag validation,
-stdout/stderr separation for headless modes, and --once rendering.
+CLI wiring coverage for zview_cli.main: verb dispatch, default-verb splicing,
+flag validation per verb, and stdout/stderr separation for headless modes.
 """
 
 import json
@@ -29,113 +29,137 @@ def _invoke(monkeypatch, capsys, argv: list[str]):
     return rc, captured.out, captured.err
 
 
-def test_once_json_stdout_is_valid_json(monkeypatch, capsys):
+def test_normalize_argv_splices_live_for_bare_invocation():
+    assert zview_cli._normalize_argv(["-e", "x", "-r", "jlink", "-t", "y"]) == [
+        "live",
+        "-e",
+        "x",
+        "-r",
+        "jlink",
+        "-t",
+        "y",
+    ]
+
+
+def test_normalize_argv_passes_known_commands_through():
+    for cmd in zview_cli.KNOWN_COMMANDS:
+        assert zview_cli._normalize_argv([cmd, "-e", "x"]) == [cmd, "-e", "x"]
+
+
+def test_normalize_argv_passes_help_through():
+    assert zview_cli._normalize_argv(["--help"]) == ["--help"]
+    assert zview_cli._normalize_argv(["-h"]) == ["-h"]
+
+
+def test_dump_replay_json_stdout_is_valid_json(monkeypatch, capsys):
     rc, out, _ = _invoke(
         monkeypatch,
         capsys,
-        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once", "--json"],
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "--json"],
     )
     assert rc == 0
     data = json.loads(out)
     assert "threads" in data and len(data["threads"]) >= 1
 
 
-def test_once_json_keeps_stdout_clean_of_status_lines(monkeypatch, capsys):
+def test_dump_replay_json_keeps_stdout_clean(monkeypatch, capsys):
     rc, out, err = _invoke(
         monkeypatch,
         capsys,
-        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once", "--json"],
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "--json"],
     )
     assert rc == 0
-    # Stdout must contain ONLY the JSON document; any status line on stdout
-    # would both fail json.loads and leak diagnostic strings.
     stripped = out.strip()
-    assert stripped.startswith("{")
-    assert stripped.endswith("}")
+    assert stripped.startswith("{") and stripped.endswith("}")
     assert "Loaded cached ELF" not in out
-    assert "Connected to GDB" not in out
-    # Diagnostic that DID fire must be on stderr.
     assert "Loaded cached ELF" in err or "Loading ELF" in err
 
 
-def test_once_human_readable_lists_threads(monkeypatch, capsys):
+def test_dump_replay_human_readable(monkeypatch, capsys):
     rc, out, _ = _invoke(
         monkeypatch,
         capsys,
-        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--once"],
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE)],
     )
     assert rc == 0
-    for expected_thread in ("stress_id", "idle", "main"):
-        assert expected_thread in out
-    assert "stack=" in out
-    assert "watermark=" in out
+    for thread in ("stress_id", "idle", "main"):
+        assert thread in out
+    assert "stack=" in out and "watermark=" in out
 
 
-def test_requires_runner_without_replay(monkeypatch, capsys):
+def test_dump_frame_arg_skips_to_requested_frame(monkeypatch, capsys):
+    """--frame 3 emits a different frame than --frame 1 (CPU deltas accumulate over replay)."""
+    rc1, out1, _ = _invoke(
+        monkeypatch,
+        capsys,
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "--json", "--frame", "1"],
+    )
+    rc3, out3, _ = _invoke(
+        monkeypatch,
+        capsys,
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "--json", "--frame", "3"],
+    )
+    assert rc1 == 0 and rc3 == 0
+    f1 = json.loads(out1)
+    f3 = json.loads(out3)
+    # Same threads, different runtime state across frames.
+    assert {t["name"] for t in f1["threads"]} == {t["name"] for t in f3["threads"]}
+    cpu1 = sorted(t["runtime"]["cpu_normalized"] for t in f1["threads"])
+    cpu3 = sorted(t["runtime"]["cpu_normalized"] for t in f3["threads"])
+    assert cpu1 != cpu3
+
+
+def test_dump_rejects_zero_or_negative_frame(monkeypatch, capsys):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "--frame", "0"],
+    )
+    assert rc == 2
+    assert "--frame" in err
+
+
+def test_dump_requires_input_or_runner_target(monkeypatch, capsys):
+    rc, _, err = _invoke(monkeypatch, capsys, ["dump", "-e", str(_ELF)])
+    assert rc == 2
+    assert "--input" in err
+
+
+def test_dump_input_and_runner_are_mutually_exclusive(monkeypatch, capsys):
+    rc, _, err = _invoke(
+        monkeypatch,
+        capsys,
+        ["dump", "-e", str(_ELF), "-i", str(_FIXTURE), "-r", "gdb", "-t", "localhost:1"],
+    )
+    assert rc == 2
+    assert "mutually exclusive" in err
+
+
+def test_live_requires_runner(monkeypatch, capsys):
     rc, _, err = _invoke(monkeypatch, capsys, ["-e", str(_ELF)])
     assert rc == 2
     assert "--runner" in err
 
 
-def test_requires_runner_target_without_replay(monkeypatch, capsys):
+def test_live_requires_runner_target(monkeypatch, capsys):
     rc, _, err = _invoke(monkeypatch, capsys, ["-e", str(_ELF), "-r", "gdb"])
     assert rc == 2
     assert "--runner-target" in err
 
 
-def test_snapshot_and_replay_are_mutually_exclusive(monkeypatch, capsys, tmp_path):
+def test_record_requires_duration_or_frames(monkeypatch, capsys, tmp_path):
     rc, _, err = _invoke(
         monkeypatch,
         capsys,
         [
-            "-e",
-            str(_ELF),
-            "--replay",
-            str(_FIXTURE),
-            "--snapshot",
-            str(tmp_path / "x.ndjson.gz"),
-            "--frames",
-            "1",
-        ],
-    )
-    assert rc == 2
-    assert "mutually exclusive" in err
-
-
-def test_snapshot_and_once_are_mutually_exclusive(monkeypatch, capsys, tmp_path):
-    rc, _, err = _invoke(
-        monkeypatch,
-        capsys,
-        [
+            "record",
             "-e",
             str(_ELF),
             "-r",
             "gdb",
             "-t",
             "localhost:1",
-            "--snapshot",
-            str(tmp_path / "x.ndjson.gz"),
-            "--once",
-            "--frames",
-            "1",
-        ],
-    )
-    assert rc == 2
-    assert "mutually exclusive" in err
-
-
-def test_snapshot_requires_duration_or_frames(monkeypatch, capsys, tmp_path):
-    rc, _, err = _invoke(
-        monkeypatch,
-        capsys,
-        [
-            "-e",
-            str(_ELF),
-            "-r",
-            "gdb",
-            "-t",
-            "localhost:1",
-            "--snapshot",
+            "-o",
             str(tmp_path / "x.ndjson.gz"),
         ],
     )
@@ -143,29 +167,11 @@ def test_snapshot_requires_duration_or_frames(monkeypatch, capsys, tmp_path):
     assert "--duration" in err or "--frames" in err
 
 
-def test_json_requires_once(monkeypatch, capsys):
-    rc, _, err = _invoke(
-        monkeypatch,
-        capsys,
-        ["-e", str(_ELF), "--replay", str(_FIXTURE), "--json"],
-    )
-    assert rc == 2
-    assert "--once" in err
+def test_record_dispatches_with_frames_bound(monkeypatch, capsys, tmp_path):
+    recorded: list[dict] = []
 
-
-def test_snapshot_dispatches_with_bound(monkeypatch, capsys, tmp_path):
-    """main() forwards --frames to record_session and reports the captured count."""
-    recorded_calls: list[dict] = []
-
-    def fake_record(backend, elf_path, out_path, duration=None, frames=None, period=0.1):
-        recorded_calls.append(
-            {
-                "out_path": str(out_path),
-                "duration": duration,
-                "frames": frames,
-                "period": period,
-            }
-        )
+    def fake_record(backend, elf_path, out_path, **kwargs):
+        recorded.append({"out_path": str(out_path), **kwargs})
         return 7
 
     monkeypatch.setattr(zview_cli, "record_session", fake_record)
@@ -175,21 +181,76 @@ def test_snapshot_dispatches_with_bound(monkeypatch, capsys, tmp_path):
         monkeypatch,
         capsys,
         [
+            "record",
             "-e",
             str(_ELF),
             "-r",
             "gdb",
             "-t",
             "localhost:1",
-            "--snapshot",
+            "-o",
             str(out_file),
             "--frames",
             "5",
         ],
     )
-
     assert rc == 0
-    assert len(recorded_calls) == 1
-    assert recorded_calls[0]["frames"] == 5
-    assert recorded_calls[0]["duration"] is None
+    assert len(recorded) == 1
+    assert recorded[0]["frames"] == 5
+    assert recorded[0]["duration"] is None
     assert f"Recorded 7 frames to {out_file}" in out
+
+
+def test_record_forwards_heap_flag(monkeypatch, capsys, tmp_path):
+    recorded: list[dict] = []
+
+    def fake_record(backend, elf_path, out_path, **kwargs):
+        recorded.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(zview_cli, "record_session", fake_record)
+
+    rc, _, _ = _invoke(
+        monkeypatch,
+        capsys,
+        [
+            "record",
+            "-e",
+            str(_ELF),
+            "-r",
+            "gdb",
+            "-t",
+            "localhost:1",
+            "-o",
+            str(tmp_path / "x.ndjson.gz"),
+            "--frames",
+            "1",
+            "--heap",
+            "my_kernel_heap",
+        ],
+    )
+    assert rc == 0
+    assert recorded[0]["heap_detail"] == "my_kernel_heap"
+
+
+def test_replay_no_pacing_passes_to_scraper(monkeypatch, capsys):
+    """--no-pacing constructs the ReplayScraper with honor_timing=False."""
+    captured: dict = {}
+    real_cls = zview_cli.ReplayScraper
+
+    class SpyReplay(real_cls):
+        def __init__(self, *args, **kwargs):
+            captured["honor_timing"] = kwargs.get("honor_timing", True)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(zview_cli, "ReplayScraper", SpyReplay)
+    monkeypatch.setattr(zview_cli, "tui_run", lambda *a, **kw: None)
+    monkeypatch.setattr(zview_cli.curses, "wrapper", lambda fn, *a, **kw: fn(None, *a, **kw))
+
+    rc, _, _ = _invoke(
+        monkeypatch,
+        capsys,
+        ["replay", "-e", str(_ELF), "-i", str(_FIXTURE), "--no-pacing"],
+    )
+    assert rc == 0
+    assert captured["honor_timing"] is False

--- a/tests/test_elf_parser.py
+++ b/tests/test_elf_parser.py
@@ -22,7 +22,6 @@ def parser(elf_path):
 
 
 def test_symbol_address_lookup(parser):
-    """Test retrieving the address of the kernel object."""
     addr = parser.get_symbol_info("_kernel", "address")
     assert len(addr) == 1
     assert isinstance(addr[0], int)
@@ -30,7 +29,6 @@ def test_symbol_address_lookup(parser):
 
 
 def test_struct_member_offsets(parser):
-    """Test parsing structure offsets (padding logic check)."""
     ts_offset = parser.get_struct_member_offset("k_thread", "base")
     assert ts_offset == 0
 
@@ -39,13 +37,11 @@ def test_struct_member_offsets(parser):
 
 
 def test_struct_size(parser):
-    """Test reading the total size of the struct."""
     size = parser.get_struct_size("k_thread")
     assert size == 192
 
 
 def test_find_variable_by_struct_type(parser):
-    """Test finding variables that are instances of a specific struct."""
     vars_found = parser.find_struct_variable_names("k_thread")
 
     assert vars_found is not None
@@ -58,12 +54,7 @@ def test_struct_not_found(parser):
 
 
 def test_find_struct_variable_names_order_is_deterministic(elf_path):
-    """Multiple ElfInspector instances must return identical variable order.
-
-    The underlying dedup must not rely on set() iteration order, which is
-    randomized per-process via PYTHONHASHSEED and would break the
-    record/replay lockstep contract (same ELF, different polling order).
-    """
+    """Two fresh ``ElfInspector`` instances on the same ELF return identical order."""
     first = ElfInspector(str(elf_path)).find_struct_variable_names("k_thread")
     second = ElfInspector(str(elf_path)).find_struct_variable_names("k_thread")
     assert first is not None

--- a/tests/test_elf_parser.py
+++ b/tests/test_elf_parser.py
@@ -55,3 +55,16 @@ def test_find_variable_by_struct_type(parser):
 def test_struct_not_found(parser):
     with pytest.raises(LookupError):
         parser.get_struct_size("k_struct")
+
+
+def test_find_struct_variable_names_order_is_deterministic(elf_path):
+    """Multiple ElfInspector instances must return identical variable order.
+
+    The underlying dedup must not rely on set() iteration order, which is
+    randomized per-process via PYTHONHASHSEED and would break the
+    record/replay lockstep contract (same ELF, different polling order).
+    """
+    first = ElfInspector(str(elf_path)).find_struct_variable_names("k_thread")
+    second = ElfInspector(str(elf_path)).find_struct_variable_names("k_thread")
+    assert first is not None
+    assert first == second

--- a/tests/test_heap_walker.py
+++ b/tests/test_heap_walker.py
@@ -26,9 +26,17 @@ class FakeScraper:
 
 def _make_walker(scraper: FakeScraper) -> ZScraper:
     """Bypass ZScraper.__init__ (which requires an ELF) and seed only what the walker reads."""
+    from kernel.layout import KernelLayout
+
     walker = object.__new__(ZScraper)
     walker._m_scraper = scraper
-    walker._offsets = {"heap_info": {"end_chunk": 0}}
+    walker._layout = KernelLayout(
+        threads_head=0,
+        thread_next=0,
+        stack_start=0,
+        stack_size=0,
+        heap_end_chunk=0,
+    )
     return walker
 
 

--- a/tests/test_heap_walker.py
+++ b/tests/test_heap_walker.py
@@ -25,7 +25,7 @@ class FakeScraper:
 
 
 def _make_walker(scraper: FakeScraper) -> ZScraper:
-    """Bypass ZScraper.__init__ (which requires an ELF) and seed only what the walker reads."""
+    """Bypass ``ZScraper.__init__`` and seed only what the walker reads."""
     from kernel.layout import KernelLayout
 
     walker = object.__new__(ZScraper)

--- a/tests/test_recording_replay.py
+++ b/tests/test_recording_replay.py
@@ -143,7 +143,7 @@ def test_unsupported_schema_raises(tmp_path):
 
 
 def test_begin_batch_at_trailing_disconnect_signals_completion(sample_path, sample_backend):
-    """Starting a new frame after the recording's last op raises ReplayComplete, not drift."""
+    """``begin_batch`` past the trailing ``disconnect`` raises ReplayComplete."""
     _record_session(sample_path, sample_backend)
 
     replay = ReplayScraper(sample_path, honor_timing=False)
@@ -162,7 +162,7 @@ def test_begin_batch_at_trailing_disconnect_signals_completion(sample_path, samp
 
 
 def test_partial_replay_allows_early_disconnect(sample_path, sample_backend):
-    """Stopping replay mid-recording must not raise; disconnect is a lifecycle hint."""
+    """Disconnect mid-recording must not raise."""
     _record_session(sample_path, sample_backend)
 
     replay = ReplayScraper(sample_path)
@@ -213,14 +213,14 @@ def _write_paced_recording(path: Path, deltas_sec: list[float]) -> None:
 
 
 def test_replay_is_not_live(sample_path, sample_backend):
-    """ReplayScraper advertises is_live=False so the TUI can block mutations."""
+    """``ReplayScraper.is_live`` is False."""
     _record_session(sample_path, sample_backend)
     replay = ReplayScraper(sample_path)
     assert replay.is_live is False
 
 
 def test_live_backends_advertise_is_live_by_default():
-    """AbstractScraper default is is_live=True; concrete live backends inherit it."""
+    """``AbstractScraper.is_live`` default is True."""
     from backend.gdb import GDBScraper
 
     scraper = GDBScraper("localhost:1234")
@@ -228,7 +228,7 @@ def test_live_backends_advertise_is_live_by_default():
 
 
 def test_honor_timing_sleeps_to_recorded_wall_clock(tmp_path):
-    """With honor_timing=True, replay paces itself to the recorded inter-op gap."""
+    """``honor_timing=True`` paces calls to the recorded inter-op gap."""
     import time as _time
 
     path = tmp_path / "paced.ndjson.gz"
@@ -247,7 +247,7 @@ def test_honor_timing_sleeps_to_recorded_wall_clock(tmp_path):
 
 
 def test_honor_timing_false_drains_instantly(tmp_path):
-    """With honor_timing=False, the same recording replays without any sleep."""
+    """``honor_timing=False`` drains the recording without sleeping."""
     import time as _time
 
     path = tmp_path / "fast.ndjson.gz"

--- a/tests/test_recording_replay.py
+++ b/tests/test_recording_replay.py
@@ -141,6 +141,20 @@ def test_unsupported_schema_raises(tmp_path):
         ReplayScraper(path).connect()
 
 
+def test_partial_replay_allows_early_disconnect(sample_path, sample_backend):
+    """Stopping replay mid-recording must not raise; disconnect is a lifecycle hint."""
+    _record_session(sample_path, sample_backend)
+
+    replay = ReplayScraper(sample_path)
+    replay.connect()
+    replay.begin_batch()
+    replay.read32(0x1000, 1)
+
+    replay.disconnect()  # early stop; further entries remain unconsumed
+
+    assert not replay.is_connected
+
+
 def test_payload_is_gzipped(sample_path, sample_backend):
     _record_session(sample_path, sample_backend)
 

--- a/tests/test_recording_replay.py
+++ b/tests/test_recording_replay.py
@@ -11,6 +11,7 @@ import pytest
 from backend.base import AbstractScraper
 from backend.recording import SCHEMA_VERSION, RecordingScraper
 from backend.replay import (
+    ReplayComplete,
     ReplayExhausted,
     ReplayMismatch,
     ReplayScraper,
@@ -141,6 +142,25 @@ def test_unsupported_schema_raises(tmp_path):
         ReplayScraper(path).connect()
 
 
+def test_begin_batch_at_trailing_disconnect_signals_completion(sample_path, sample_backend):
+    """Starting a new frame after the recording's last op raises ReplayComplete, not drift."""
+    _record_session(sample_path, sample_backend)
+
+    replay = ReplayScraper(sample_path, honor_timing=False)
+    replay.connect()
+    replay.begin_batch()
+    replay.read32(0x1000, 1)
+    replay.read32(0x1004, 4)
+    replay.read64(0x2000)
+    replay.read_bytes(0x3000, 16)
+    replay.end_batch()
+
+    # Cursor is now at the trailing "disconnect" entry. Starting another frame
+    # is a clean end-of-stream rather than a mismatch.
+    with pytest.raises(ReplayComplete):
+        replay.begin_batch()
+
+
 def test_partial_replay_allows_early_disconnect(sample_path, sample_backend):
     """Stopping replay mid-recording must not raise; disconnect is a lifecycle hint."""
     _record_session(sample_path, sample_backend)
@@ -166,3 +186,80 @@ def test_payload_is_gzipped(sample_path, sample_backend):
     with gzip.open(sample_path, "rt", encoding="utf-8") as fp:
         header = json.loads(fp.readline())
     assert header["schema"] == SCHEMA_VERSION
+
+
+def _write_paced_recording(path: Path, deltas_sec: list[float]) -> None:
+    """Write a minimal recording with the given inter-op wall-clock deltas."""
+    import time as _time
+
+    t0 = _time.time()
+    header = {"schema": SCHEMA_VERSION, "endianess": "<", "created_at": t0}
+    entries = [{"t": t0, "op": "connect", "args": {}}]
+    cursor = t0
+    for i, delta in enumerate(deltas_sec):
+        cursor += delta
+        entries.append(
+            {
+                "t": cursor,
+                "op": "read32",
+                "args": {"at": i, "amount": 1},
+                "result": [i],
+            }
+        )
+    with gzip.open(path, "wt", encoding="utf-8") as fp:
+        fp.write(json.dumps(header) + "\n")
+        for entry in entries:
+            fp.write(json.dumps(entry) + "\n")
+
+
+def test_replay_is_not_live(sample_path, sample_backend):
+    """ReplayScraper advertises is_live=False so the TUI can block mutations."""
+    _record_session(sample_path, sample_backend)
+    replay = ReplayScraper(sample_path)
+    assert replay.is_live is False
+
+
+def test_live_backends_advertise_is_live_by_default():
+    """AbstractScraper default is is_live=True; concrete live backends inherit it."""
+    from backend.gdb import GDBScraper
+
+    scraper = GDBScraper("localhost:1234")
+    assert scraper.is_live is True
+
+
+def test_honor_timing_sleeps_to_recorded_wall_clock(tmp_path):
+    """With honor_timing=True, replay paces itself to the recorded inter-op gap."""
+    import time as _time
+
+    path = tmp_path / "paced.ndjson.gz"
+    _write_paced_recording(path, deltas_sec=[0.0, 0.25])
+
+    replay = ReplayScraper(path, honor_timing=True)
+    replay.connect()
+    replay.read32(0, 1)
+
+    start = _time.monotonic()
+    replay.read32(1, 1)
+    elapsed = _time.monotonic() - start
+
+    # Second read is 0.25 s past the first; allow slack for scheduler jitter.
+    assert elapsed >= 0.2
+
+
+def test_honor_timing_false_drains_instantly(tmp_path):
+    """With honor_timing=False, the same recording replays without any sleep."""
+    import time as _time
+
+    path = tmp_path / "fast.ndjson.gz"
+    _write_paced_recording(path, deltas_sec=[1.0, 1.0])
+
+    replay = ReplayScraper(path, honor_timing=False)
+
+    start = _time.monotonic()
+    replay.connect()
+    replay.read32(0, 1)
+    replay.read32(1, 1)
+    elapsed = _time.monotonic() - start
+
+    # Recording spans 2 s; honor_timing=False drains it in a few ms.
+    assert elapsed < 0.1

--- a/tests/test_replay_integration.py
+++ b/tests/test_replay_integration.py
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-End-to-end replay integration: feed a recorded .ndjson.gz through ReplayScraper
-and a real ZScraper; verify the polling pipeline produces the state captured
-in the matching golden JSON.
-"""
+"""End-to-end replay integration against a recorded fixture and its golden JSON."""
 
 import json
 import queue
@@ -74,14 +70,14 @@ def _last_valid_frame(frames: list[dict]) -> dict:
 
 
 def test_replay_produces_frames(replay_run):
-    """Shape: replay drains the recording into one or more valid data frames."""
+    """Replay drains the recording into one or more valid data frames."""
     frames, _ = replay_run
     valid = [f for f in frames if "threads" in f]
     assert valid, "Replay produced no valid frames"
 
 
 def test_thread_shape(replay_run):
-    """Shape: every emitted thread carries a non-empty name and a positive stack size."""
+    """Every emitted thread has a non-empty name and a positive stack size."""
     frames, _ = replay_run
     last = _last_valid_frame(frames)
     threads: list[ThreadInfo] = last["threads"]
@@ -95,7 +91,7 @@ def test_thread_shape(replay_run):
 
 
 def test_heap_shape(replay_run):
-    """Shape: emitted heaps report non-negative sizes consistent with each other."""
+    """Emitted heaps report non-negative sizes; max ≥ allocated."""
     frames, _ = replay_run
     last = _last_valid_frame(frames)
     heaps: list[HeapInfo] = last.get("heaps", [])
@@ -107,7 +103,7 @@ def test_heap_shape(replay_run):
 
 
 def test_snapshot_thread_set_matches_golden(replay_run):
-    """Snapshot: thread names, stack starts, and stack sizes match the golden file exactly."""
+    """Thread names + stack starts + stack sizes equal the golden."""
     frames, golden = replay_run
     last = _last_valid_frame(frames)
     captured = {(t.name, t.stack_start, t.stack_size) for t in last["threads"]}
@@ -116,7 +112,7 @@ def test_snapshot_thread_set_matches_golden(replay_run):
 
 
 def test_snapshot_watermarks_match_golden(replay_run):
-    """Snapshot: per-thread watermark matches the golden exactly (replay is deterministic)."""
+    """Per-thread watermark equals the golden."""
     frames, golden = replay_run
     last = _last_valid_frame(frames)
     captured = {t.name: t.runtime.stack_watermark for t in last["threads"] if t.runtime}
@@ -129,7 +125,7 @@ def test_snapshot_watermarks_match_golden(replay_run):
 
 
 def test_snapshot_heaps_match_golden(replay_run):
-    """Snapshot: heap identity and byte counters match the golden exactly."""
+    """Heap identity + byte counters equal the golden."""
     frames, golden = replay_run
     last = _last_valid_frame(frames)
     captured = [

--- a/tests/test_replay_integration.py
+++ b/tests/test_replay_integration.py
@@ -39,7 +39,7 @@ def _discover_fixtures() -> list[tuple[Path, Path]]:
 
 def _drive_replay(recording: Path) -> list[dict]:
     """Replay a fixture through a full ZScraper polling loop; return captured frames."""
-    replay = ReplayScraper(recording)
+    replay = ReplayScraper(recording, honor_timing=False)
     with replay:
         scraper = ZScraper(replay, str(_ELF_PATH))
         scraper.update_available_threads()

--- a/tests/test_snapshot_roundtrip.py
+++ b/tests/test_snapshot_roundtrip.py
@@ -60,7 +60,8 @@ def test_serialize_frame_produces_json_safe_dict():
     assert restored["heaps"][0]["chunks"] is None
 
 
-def test_serialize_frame_omits_runtime_when_none():
+def test_serialize_frame_keeps_runtime_key_as_none():
+    """JSON consumers rely on a stable schema; runtime stays present as null."""
     thread = ThreadInfo(
         address=0x1000,
         stack_start=0x2000,
@@ -69,7 +70,7 @@ def test_serialize_frame_omits_runtime_when_none():
         runtime=None,
     )
     out = serialize_frame({"threads": [thread]})
-    assert "runtime" not in out["threads"][0]
+    assert out["threads"][0]["runtime"] is None
 
 
 def test_serialize_frame_handles_empty():

--- a/tests/test_snapshot_roundtrip.py
+++ b/tests/test_snapshot_roundtrip.py
@@ -2,11 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Covers the headless snapshot module: frame serialization, single-frame dump
-against a ReplayScraper, and Replay→Recording roundtrip yielding a valid
-recording that replays cleanly on its own.
-"""
+"""Coverage for the headless snapshot module."""
 
 import json
 from pathlib import Path
@@ -61,7 +57,7 @@ def test_serialize_frame_produces_json_safe_dict():
 
 
 def test_serialize_frame_keeps_runtime_key_as_none():
-    """JSON consumers rely on a stable schema; runtime stays present as null."""
+    """``runtime`` field stays present as null when no runtime data is set."""
     thread = ThreadInfo(
         address=0x1000,
         stack_start=0x2000,
@@ -92,7 +88,7 @@ def test_dump_single_frame_via_replay():
 
 
 def test_record_session_roundtrip(tmp_path):
-    """ReplayScraper fed into RecordingScraper should emit a replayable recording."""
+    """ReplayScraper → RecordingScraper produces a replayable recording."""
     source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "roundtrip.ndjson.gz"
 
@@ -133,7 +129,7 @@ def test_record_session_duration_bound(tmp_path):
 
 
 def test_record_session_dual_bound_first_to_hit_wins(tmp_path):
-    """With a short duration and a much larger frames target, duration terminates first."""
+    """Duration terminates first when frames is much larger."""
     source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "dual.ndjson.gz"
 
@@ -146,7 +142,7 @@ def test_record_session_dual_bound_first_to_hit_wins(tmp_path):
 
 
 def test_configure_heap_detail_sets_extra_info_address():
-    """Dereferences the heap symbol (via read32) and stores the struct pointer."""
+    """Reads the heap symbol via ``read32`` and stores the struct pointer."""
     from unittest.mock import MagicMock
 
     from orchestrator import ZScraper as _ZScraper
@@ -196,7 +192,7 @@ def test_configure_heap_detail_requires_heap_support():
 
 
 def test_dump_single_frame_propagates_fatal_error(monkeypatch):
-    """A fatal_error emitted by the polling thread surfaces as RuntimeError."""
+    """``fatal_error`` from the polling thread surfaces as ``RuntimeError``."""
 
     def fake_start(self, data_queue, stop_event, period):
         data_queue.put({"fatal_error": "synthetic backend loss"})
@@ -215,7 +211,7 @@ def test_dump_single_frame_rejects_invalid_frame():
 
 
 def test_dump_single_frame_skips_to_requested_frame():
-    """frame=N returns the Nth valid data frame, distinct from the first."""
+    """``frame=N`` returns the Nth valid data frame."""
     backend = ReplayScraper(_FIXTURE, honor_timing=False)
     f1 = dump_single_frame(backend, str(_ELF), period=0.001, frame=1, timeout=3.0)
 
@@ -229,7 +225,7 @@ def test_dump_single_frame_skips_to_requested_frame():
 
 
 def test_dump_single_frame_raises_when_recording_too_short():
-    """frame=N where N exceeds recorded frames surfaces a clear RuntimeError."""
+    """``frame`` past recording exhaustion raises ``RuntimeError``."""
     backend = ReplayScraper(_FIXTURE, honor_timing=False)
     with pytest.raises(RuntimeError, match="out of range"):
         dump_single_frame(backend, str(_ELF), period=0.001, frame=10_000, timeout=3.0)

--- a/tests/test_snapshot_roundtrip.py
+++ b/tests/test_snapshot_roundtrip.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Covers the headless snapshot module: frame serialization, single-frame dump
+against a ReplayScraper, and Replay→Recording roundtrip yielding a valid
+recording that replays cleanly on its own.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.base import HeapInfo, ThreadInfo, ThreadRuntime
+from backend.replay import ReplayScraper
+from snapshot import dump_single_frame, record_session, serialize_frame
+
+_TESTS_DIR = Path(__file__).parent
+_FIXTURE = _TESTS_DIR / "fixtures" / "recordings" / "sys_heap_v4.3.ndjson.gz"
+_ELF = _TESTS_DIR / "fixtures" / "zephyr.elf"
+
+
+def test_serialize_frame_produces_json_safe_dict():
+    runtime = ThreadRuntime(
+        cpu=1.0,
+        cpu_normalized=0.5,
+        active=True,
+        stack_watermark=100,
+        stack_watermark_percent=25.0,
+    )
+    thread = ThreadInfo(
+        address=0x1000,
+        stack_start=0x2000,
+        stack_size=400,
+        name="main",
+        runtime=runtime,
+    )
+    heap = HeapInfo(
+        name="my_heap",
+        address=0x3000,
+        free_bytes=1024,
+        allocated_bytes=512,
+        max_allocated_bytes=800,
+        usage_percent=50.0,
+        chunks=None,
+    )
+
+    out = serialize_frame({"threads": [thread], "heaps": [heap]})
+
+    # Roundtrips through json without error.
+    serialized = json.dumps(out)
+    restored = json.loads(serialized)
+
+    assert restored["threads"][0]["name"] == "main"
+    assert restored["threads"][0]["address"] == 0x1000
+    assert restored["threads"][0]["runtime"]["cpu"] == 1.0
+    assert restored["heaps"][0]["free_bytes"] == 1024
+    assert restored["heaps"][0]["chunks"] is None
+
+
+def test_serialize_frame_omits_runtime_when_none():
+    thread = ThreadInfo(
+        address=0x1000,
+        stack_start=0x2000,
+        stack_size=400,
+        name="probe",
+        runtime=None,
+    )
+    out = serialize_frame({"threads": [thread]})
+    assert "runtime" not in out["threads"][0]
+
+
+def test_serialize_frame_handles_empty():
+    assert serialize_frame({}) == {}
+    assert serialize_frame({"threads": []}) == {"threads": []}
+
+
+def test_dump_single_frame_via_replay():
+    backend = ReplayScraper(_FIXTURE)
+    frame = dump_single_frame(backend, str(_ELF), period=0.001, timeout=3.0)
+
+    assert "threads" in frame
+    names = {t.name for t in frame["threads"]}
+    assert names == {"stress_id", "idle", "main"}
+
+    # JSON shape sanity
+    payload = serialize_frame(frame)
+    json.dumps(payload)  # must not raise
+
+
+def test_record_session_roundtrip(tmp_path):
+    """ReplayScraper fed into RecordingScraper should emit a replayable recording."""
+    source = ReplayScraper(_FIXTURE)
+    out_path = tmp_path / "roundtrip.ndjson.gz"
+
+    captured = record_session(source, str(_ELF), out_path, duration=1.5, period=0.001)
+    assert out_path.exists()
+    assert captured >= 1
+
+    # Replay the recorded session — it must yield at least one valid frame.
+    replay2 = ReplayScraper(out_path)
+    frame2 = dump_single_frame(replay2, str(_ELF), period=0.001, timeout=3.0)
+    assert "threads" in frame2
+    assert {t.name for t in frame2["threads"]} == {"stress_id", "idle", "main"}
+
+
+def test_record_session_respects_frames_bound(tmp_path):
+    source = ReplayScraper(_FIXTURE)
+    out_path = tmp_path / "bounded.ndjson.gz"
+
+    captured = record_session(source, str(_ELF), out_path, frames=2, period=0.001)
+    assert captured == 2
+
+
+def test_record_session_requires_a_bound(tmp_path):
+    source = ReplayScraper(_FIXTURE)
+    with pytest.raises(ValueError, match="duration or frames"):
+        record_session(source, str(_ELF), tmp_path / "no_bound.ndjson.gz")
+
+
+def test_record_session_duration_bound(tmp_path):
+    source = ReplayScraper(_FIXTURE)
+    out_path = tmp_path / "duration.ndjson.gz"
+
+    # period dominates frame spacing; duration=0.1s / period=0.05s yields ~2 frames.
+    captured = record_session(source, str(_ELF), out_path, duration=0.1, period=0.05)
+
+    assert out_path.exists()
+    assert 1 <= captured <= 5
+
+
+def test_record_session_dual_bound_first_to_hit_wins(tmp_path):
+    """With a short duration and a much larger frames target, duration terminates first."""
+    source = ReplayScraper(_FIXTURE)
+    out_path = tmp_path / "dual.ndjson.gz"
+
+    captured = record_session(source, str(_ELF), out_path, duration=0.1, frames=100, period=0.05)
+
+    assert out_path.exists()
+    # Duration wins: captured is nowhere near the frames target.
+    assert captured < 100
+    assert captured <= 5
+
+
+def test_dump_single_frame_propagates_fatal_error(monkeypatch):
+    """A fatal_error emitted by the polling thread surfaces as RuntimeError."""
+
+    def fake_start(self, data_queue, stop_event, period):
+        data_queue.put({"fatal_error": "synthetic backend loss"})
+
+    monkeypatch.setattr("orchestrator.ZScraper.start_polling_thread", fake_start)
+
+    backend = ReplayScraper(_FIXTURE)
+    with pytest.raises(RuntimeError, match="synthetic backend loss"):
+        dump_single_frame(backend, str(_ELF), period=0.001, timeout=1.0)

--- a/tests/test_snapshot_roundtrip.py
+++ b/tests/test_snapshot_roundtrip.py
@@ -78,7 +78,7 @@ def test_serialize_frame_handles_empty():
 
 
 def test_dump_single_frame_via_replay():
-    backend = ReplayScraper(_FIXTURE)
+    backend = ReplayScraper(_FIXTURE, honor_timing=False)
     frame = dump_single_frame(backend, str(_ELF), period=0.001, timeout=3.0)
 
     assert "threads" in frame
@@ -92,7 +92,7 @@ def test_dump_single_frame_via_replay():
 
 def test_record_session_roundtrip(tmp_path):
     """ReplayScraper fed into RecordingScraper should emit a replayable recording."""
-    source = ReplayScraper(_FIXTURE)
+    source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "roundtrip.ndjson.gz"
 
     captured = record_session(source, str(_ELF), out_path, duration=1.5, period=0.001)
@@ -100,14 +100,14 @@ def test_record_session_roundtrip(tmp_path):
     assert captured >= 1
 
     # Replay the recorded session — it must yield at least one valid frame.
-    replay2 = ReplayScraper(out_path)
+    replay2 = ReplayScraper(out_path, honor_timing=False)
     frame2 = dump_single_frame(replay2, str(_ELF), period=0.001, timeout=3.0)
     assert "threads" in frame2
     assert {t.name for t in frame2["threads"]} == {"stress_id", "idle", "main"}
 
 
 def test_record_session_respects_frames_bound(tmp_path):
-    source = ReplayScraper(_FIXTURE)
+    source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "bounded.ndjson.gz"
 
     captured = record_session(source, str(_ELF), out_path, frames=2, period=0.001)
@@ -115,13 +115,13 @@ def test_record_session_respects_frames_bound(tmp_path):
 
 
 def test_record_session_requires_a_bound(tmp_path):
-    source = ReplayScraper(_FIXTURE)
+    source = ReplayScraper(_FIXTURE, honor_timing=False)
     with pytest.raises(ValueError, match="duration or frames"):
         record_session(source, str(_ELF), tmp_path / "no_bound.ndjson.gz")
 
 
 def test_record_session_duration_bound(tmp_path):
-    source = ReplayScraper(_FIXTURE)
+    source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "duration.ndjson.gz"
 
     # period dominates frame spacing; duration=0.1s / period=0.05s yields ~2 frames.
@@ -133,7 +133,7 @@ def test_record_session_duration_bound(tmp_path):
 
 def test_record_session_dual_bound_first_to_hit_wins(tmp_path):
     """With a short duration and a much larger frames target, duration terminates first."""
-    source = ReplayScraper(_FIXTURE)
+    source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "dual.ndjson.gz"
 
     captured = record_session(source, str(_ELF), out_path, duration=0.1, frames=100, period=0.05)
@@ -144,6 +144,56 @@ def test_record_session_dual_bound_first_to_hit_wins(tmp_path):
     assert captured <= 5
 
 
+def test_configure_heap_detail_sets_extra_info_address():
+    """Dereferences the heap symbol (via read32) and stores the struct pointer."""
+    from unittest.mock import MagicMock
+
+    from orchestrator import ZScraper as _ZScraper
+    from snapshot import _configure_heap_detail
+
+    scraper = _ZScraper.__new__(_ZScraper)
+    scraper.has_heaps = True
+    scraper._k_heap_addresses = {"my_heap": [0x1000]}
+    scraper.extra_info_heap_address = None
+
+    recorder = MagicMock()
+    recorder.read32.return_value = [0x5000]
+
+    _configure_heap_detail(scraper, recorder, "my_heap")
+
+    assert scraper.extra_info_heap_address == 0x5000
+    recorder.begin_batch.assert_called_once()
+    recorder.end_batch.assert_called_once()
+    recorder.read32.assert_called_once_with(0x1000)
+
+
+def test_configure_heap_detail_unknown_heap_raises():
+    from unittest.mock import MagicMock
+
+    from orchestrator import ZScraper as _ZScraper
+    from snapshot import _configure_heap_detail
+
+    scraper = _ZScraper.__new__(_ZScraper)
+    scraper.has_heaps = True
+    scraper._k_heap_addresses = {"my_heap": [0x1000]}
+
+    with pytest.raises(ValueError, match="not found"):
+        _configure_heap_detail(scraper, MagicMock(), "nonexistent")
+
+
+def test_configure_heap_detail_requires_heap_support():
+    from unittest.mock import MagicMock
+
+    from orchestrator import ZScraper as _ZScraper
+    from snapshot import _configure_heap_detail
+
+    scraper = _ZScraper.__new__(_ZScraper)
+    scraper.has_heaps = False
+
+    with pytest.raises(ValueError, match="no k_heap"):
+        _configure_heap_detail(scraper, MagicMock(), "any")
+
+
 def test_dump_single_frame_propagates_fatal_error(monkeypatch):
     """A fatal_error emitted by the polling thread surfaces as RuntimeError."""
 
@@ -152,6 +202,33 @@ def test_dump_single_frame_propagates_fatal_error(monkeypatch):
 
     monkeypatch.setattr("orchestrator.ZScraper.start_polling_thread", fake_start)
 
-    backend = ReplayScraper(_FIXTURE)
+    backend = ReplayScraper(_FIXTURE, honor_timing=False)
     with pytest.raises(RuntimeError, match="synthetic backend loss"):
         dump_single_frame(backend, str(_ELF), period=0.001, timeout=1.0)
+
+
+def test_dump_single_frame_rejects_invalid_frame():
+    backend = ReplayScraper(_FIXTURE, honor_timing=False)
+    with pytest.raises(ValueError, match="frame must be >= 1"):
+        dump_single_frame(backend, str(_ELF), frame=0)
+
+
+def test_dump_single_frame_skips_to_requested_frame():
+    """frame=N returns the Nth valid data frame, distinct from the first."""
+    backend = ReplayScraper(_FIXTURE, honor_timing=False)
+    f1 = dump_single_frame(backend, str(_ELF), period=0.001, frame=1, timeout=3.0)
+
+    backend2 = ReplayScraper(_FIXTURE, honor_timing=False)
+    f3 = dump_single_frame(backend2, str(_ELF), period=0.001, frame=3, timeout=3.0)
+
+    assert {t.name for t in f1["threads"]} == {t.name for t in f3["threads"]}
+    cpu_f1 = sorted(t.runtime.cpu_normalized for t in f1["threads"])
+    cpu_f3 = sorted(t.runtime.cpu_normalized for t in f3["threads"])
+    assert cpu_f1 != cpu_f3
+
+
+def test_dump_single_frame_raises_when_recording_too_short():
+    """frame=N where N exceeds recorded frames surfaces a clear RuntimeError."""
+    backend = ReplayScraper(_FIXTURE, honor_timing=False)
+    with pytest.raises(RuntimeError, match="out of range"):
+        dump_single_frame(backend, str(_ELF), period=0.001, frame=10_000, timeout=3.0)

--- a/tests/test_thread_walker.py
+++ b/tests/test_thread_walker.py
@@ -54,10 +54,15 @@ class FakeElf:
 #   2: stack_size
 #   3: next_thread
 #   4-7: name (16 bytes)
-OFFSETS = {
-    "k_thread": {"next_thread": 12, "name": 16},
-    "thread_info": {"stack_start": 4, "stack_size": 8},
-}
+from kernel.layout import KernelLayout  # noqa: E402
+
+LAYOUT = KernelLayout(
+    threads_head=0,  # unused by walker (head address comes as arg)
+    thread_next=12,
+    stack_start=4,
+    stack_size=8,
+    thread_name=16,
+)
 HEAD_ADDR = 0x500
 
 
@@ -79,14 +84,14 @@ def _make_thread(
 
 def test_zero_head_address_returns_empty():
     scraper = FakeScraper({})
-    threads = walk_thread_list(scraper, FakeElf(), 0, OFFSETS, "little", has_names=True)
+    threads = walk_thread_list(scraper, FakeElf(), 0, LAYOUT, "little", has_names=True)
     assert threads == {}
     assert scraper.batch_count == 1
 
 
 def test_zero_head_pointer_returns_empty():
     scraper = FakeScraper({HEAD_ADDR: (0,)})
-    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True)
+    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True)
     assert threads == {}
 
 
@@ -99,7 +104,7 @@ def test_single_thread_walk():
         }
     )
 
-    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True)
+    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True)
 
     assert list(threads) == ["main"]
     t = threads["main"]
@@ -121,7 +126,7 @@ def test_linked_list_multiple_threads():
         }
     )
 
-    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True)
+    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True)
 
     assert set(threads) == {"main", "idle", "worker"}
     assert threads["main"].stack_size == 512
@@ -139,7 +144,7 @@ def test_no_names_uses_address_fallback():
         }
     )
 
-    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=False)
+    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=False)
 
     assert list(threads) == [f"thread @ 0x{t1:X}"]
 
@@ -154,7 +159,7 @@ def test_max_threads_caps_walk():
 
     scraper = FakeScraper(memory)
     threads = walk_thread_list(
-        scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True, max_threads=3
+        scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True, max_threads=3
     )
 
     assert set(threads) == {"t0", "t1", "t2"}
@@ -164,7 +169,7 @@ def test_head_read_failure_raises_runtime_error():
     # HEAD_ADDR absent from memory -> read32 raises AssertionError from FakeScraper.
     scraper = FakeScraper({})
     with pytest.raises(RuntimeError, match="Unable to read kernel thread list"):
-        walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True)
+        walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True)
 
 
 def test_mid_walk_read_failure_raises():
@@ -172,7 +177,7 @@ def test_mid_walk_read_failure_raises():
     t1 = 0x1000
     scraper = FakeScraper({HEAD_ADDR: (t1,)})
     with pytest.raises(Exception, match="Error reading thread struct at 0x1000"):
-        walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "little", has_names=True)
+        walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "little", has_names=True)
 
 
 def test_big_endian_name_decoding():
@@ -185,6 +190,6 @@ def test_big_endian_name_decoding():
         endianess=">",
     )
 
-    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, OFFSETS, "big", has_names=True)
+    threads = walk_thread_list(scraper, FakeElf(), HEAD_ADDR, LAYOUT, "big", has_names=True)
 
     assert "main" in threads

--- a/tests/test_thread_walker.py
+++ b/tests/test_thread_walker.py
@@ -36,7 +36,7 @@ class FakeScraper:
 
 
 class FakeElf:
-    """Minimal ElfInspector stand-in; walk_thread_list only reads struct size."""
+    """Minimal ElfInspector stand-in."""
 
     def __init__(self, struct_size: int = 32):
         self._size = struct_size
@@ -67,7 +67,7 @@ HEAD_ADDR = 0x500
 
 
 def _name_to_words(name: str, slots: int = 4, endian: str = "little") -> tuple[int, ...]:
-    """Pack a NUL-terminated name into ``slots`` 32-bit words in the given endianness."""
+    """Pack ``name`` into ``slots`` 32-bit words, NUL-padded."""
     data = name.encode() + b"\x00" * (slots * 4 - len(name))
     return tuple(int.from_bytes(data[i : i + 4], endian) for i in range(0, slots * 4, 4))
 

--- a/tests/test_west_command.py
+++ b/tests/test_west_command.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Coverage for the west zview command: predicate helpers plus end-to-end
+verification of the ELF and runner injection paths. Skipped when west is
+not importable.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("west")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "west_commands"))
+
+from zview_tui_cmd import (  # noqa: E402
+    ZViewCommand,
+    _command_wants_runner,
+    _has_flag,
+    _help_requested,
+)
+
+
+def test_has_flag_short():
+    assert _has_flag(["-e", "x"], "-e", "--elf-file") is True
+
+
+def test_has_flag_long():
+    assert _has_flag(["--elf-file", "x"], "-e", "--elf-file") is True
+
+
+def test_has_flag_long_equals():
+    assert _has_flag(["--elf-file=x"], "-e", "--elf-file") is True
+
+
+def test_has_flag_absent():
+    assert _has_flag(["-r", "jlink"], "-e", "--elf-file") is False
+
+
+def test_command_wants_runner_live():
+    assert _command_wants_runner("live", []) is True
+
+
+def test_command_wants_runner_record():
+    assert _command_wants_runner("record", ["-o", "x.gz", "--frames", "1"]) is True
+
+
+def test_command_wants_runner_replay_never():
+    assert _command_wants_runner("replay", ["-i", "x.gz"]) is False
+
+
+def test_command_wants_runner_dump_with_input_no():
+    assert _command_wants_runner("dump", ["-i", "x.gz", "--json"]) is False
+
+
+def test_command_wants_runner_dump_without_input_yes():
+    assert _command_wants_runner("dump", ["--json"]) is True
+
+
+def test_help_requested_short_long():
+    assert _help_requested(["-h"]) is True
+    assert _help_requested(["--help"]) is True
+    assert _help_requested(["record", "--help"]) is True
+    assert _help_requested(["live", "-e", "x"]) is False
+
+
+# --- ELF injection ---
+
+
+@pytest.fixture
+def fake_build_dir(tmp_path, monkeypatch):
+    """tmp_path with a populated build/zephyr/zephyr.elf and runners.yaml."""
+    build = tmp_path / "build" / "zephyr"
+    build.mkdir(parents=True)
+    elf = build / "zephyr.elf"
+    elf.write_bytes(b"")
+    runners_yaml = build / "runners.yaml"
+    runners_yaml.write_text("flash-runner: jlink\nargs:\n  jlink:\n    - --device=nRF5340_xxAA\n")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_inject_elf_when_missing_uses_build_path(fake_build_dir):
+    cmd = ZViewCommand()
+    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
+
+    out = cmd._inject_elf_if_missing(["live"])
+    assert out == ["live", "-e", expected]
+
+
+def test_inject_elf_at_front_when_no_command(fake_build_dir):
+    """No command present → ELF flag goes at the front (becomes implicit live)."""
+    cmd = _make_cmd()
+    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
+
+    out = cmd._inject_elf_if_missing([])
+    assert out == ["-e", expected]
+
+
+def test_inject_elf_keeps_command_at_front_with_other_flags(fake_build_dir):
+    """The verb stays at argv[0]; -e is inserted just after it."""
+    cmd = _make_cmd()
+    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
+
+    out = cmd._inject_elf_if_missing(["dump", "--json"])
+    assert out == ["dump", "-e", expected, "--json"]
+
+
+def test_inject_elf_skips_when_e_present(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_elf_if_missing(["live", "-e", "/custom/path.elf"])
+    assert out == ["live", "-e", "/custom/path.elf"]
+
+
+def test_inject_elf_skips_when_long_form_present(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_elf_if_missing(["--elf-file=/x.elf", "live"])
+    assert out == ["--elf-file=/x.elf", "live"]
+
+
+def test_inject_elf_skips_when_help_requested(tmp_path, monkeypatch):
+    """No build dir, but --help must still pass through without dying."""
+    monkeypatch.chdir(tmp_path)
+    cmd = ZViewCommand()
+    out = cmd._inject_elf_if_missing(["--help"])
+    assert out == ["--help"]
+
+
+def test_inject_elf_dies_when_build_missing(tmp_path, monkeypatch):
+    """No build dir and no --help → log.die must be invoked."""
+    monkeypatch.chdir(tmp_path)
+    cmd = ZViewCommand()
+    with pytest.raises(SystemExit):
+        cmd._inject_elf_if_missing(["live"])
+
+
+# --- Runner injection ---
+
+
+def test_inject_runner_for_live(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_runner_if_missing(["live"])
+    assert out == ["live", "-r", "jlink", "-t", "nRF5340_xxAA"]
+
+
+def test_inject_runner_for_record(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_runner_if_missing(["record", "-o", "x.gz", "--frames", "1"])
+    # Verb stays at argv[0]; -r/-t inserted right after.
+    assert out[0] == "record"
+    assert out[1:5] == ["-r", "jlink", "-t", "nRF5340_xxAA"]
+    assert out[5:] == ["-o", "x.gz", "--frames", "1"]
+
+
+def test_inject_runner_keeps_dump_command_at_front(fake_build_dir):
+    """Regression: dump --json must not have -r/-t injected before the verb."""
+    cmd = _make_cmd()
+    out = cmd._inject_runner_if_missing(["dump", "--json"])
+    assert out[0] == "dump"
+    assert "-r" in out and "-t" in out
+    assert out.index("-r") > 0  # not at front
+
+
+def test_inject_runner_skips_replay(fake_build_dir):
+    cmd = ZViewCommand()
+    argv = ["replay", "-i", "x.gz"]
+    out = cmd._inject_runner_if_missing(argv)
+    assert out == argv
+
+
+def test_inject_runner_skips_dump_with_input(fake_build_dir):
+    cmd = ZViewCommand()
+    argv = ["dump", "-i", "x.gz", "--json"]
+    out = cmd._inject_runner_if_missing(argv)
+    assert out == argv
+
+
+def test_inject_runner_for_dump_without_input(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_runner_if_missing(["dump", "--json"])
+    assert "-r" in out and "-t" in out
+
+
+def test_inject_runner_skips_when_both_present(fake_build_dir):
+    cmd = ZViewCommand()
+    argv = ["live", "-r", "pyocd", "-t", "stm32h753zitx"]
+    out = cmd._inject_runner_if_missing(argv)
+    assert out == argv  # no duplication
+
+
+def test_inject_runner_fills_only_missing_target(fake_build_dir):
+    """Runner explicit, target missing → only -t injected."""
+    cmd = ZViewCommand()
+    out = cmd._inject_runner_if_missing(["live", "-r", "jlink"])
+    # -t injected, -r untouched. The user's explicit "-r jlink" is preserved.
+    assert "-t" in out
+    assert out.count("-r") == 1
+
+
+def test_inject_runner_skips_when_help_requested(fake_build_dir):
+    cmd = ZViewCommand()
+    out = cmd._inject_runner_if_missing(["live", "--help"])
+    assert out == ["live", "--help"]
+    # Specifically: no runners.yaml read attempted.

--- a/tests/test_west_command.py
+++ b/tests/test_west_command.py
@@ -2,12 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Coverage for the west zview command: predicate helpers plus end-to-end
-verification of the ELF and runner injection paths. Skipped when west is
-not importable.
-"""
+"""Coverage for the west zview command. Skipped when west is not importable."""
 
+import argparse
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -19,71 +16,54 @@ pytest.importorskip("west")
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "scripts" / "west_commands"))
 
-from zview_tui_cmd import (  # noqa: E402
-    ZViewCommand,
-    _command_wants_runner,
-    _has_flag,
-    _help_requested,
-)
-
-
-def test_has_flag_short():
-    assert _has_flag(["-e", "x"], "-e", "--elf-file") is True
-
-
-def test_has_flag_long():
-    assert _has_flag(["--elf-file", "x"], "-e", "--elf-file") is True
-
-
-def test_has_flag_long_equals():
-    assert _has_flag(["--elf-file=x"], "-e", "--elf-file") is True
-
-
-def test_has_flag_absent():
-    assert _has_flag(["-r", "jlink"], "-e", "--elf-file") is False
-
-
-def test_command_wants_runner_live():
-    assert _command_wants_runner("live", []) is True
-
-
-def test_command_wants_runner_record():
-    assert _command_wants_runner("record", ["-o", "x.gz", "--frames", "1"]) is True
-
-
-def test_command_wants_runner_replay_never():
-    assert _command_wants_runner("replay", ["-i", "x.gz"]) is False
-
-
-def test_command_wants_runner_dump_with_input_no():
-    assert _command_wants_runner("dump", ["-i", "x.gz", "--json"]) is False
-
-
-def test_command_wants_runner_dump_without_input_yes():
-    assert _command_wants_runner("dump", ["--json"]) is True
-
-
-def test_help_requested_short_long():
-    assert _help_requested(["-h"]) is True
-    assert _help_requested(["--help"]) is True
-    assert _help_requested(["record", "--help"]) is True
-    assert _help_requested(["live", "-e", "x"]) is False
-
-
-# --- ELF injection ---
+from zview_tui_cmd import ZViewCommand, _command_wants_runner  # noqa: E402
 
 
 def _make_cmd() -> ZViewCommand:
-    """ZViewCommand with the minimal config that die/err/wrn need outside a west session."""
+    """``ZViewCommand`` with a stub ``config`` so ``die``/``err``/``wrn`` work."""
     cmd = ZViewCommand()
     cmd.config = MagicMock()
     cmd.config.getboolean.return_value = False
     return cmd
 
 
+def _ns(**kwargs) -> argparse.Namespace:
+    """Build a namespace with default fields; ``kwargs`` override."""
+    defaults = {
+        "cmd": "live",
+        "elf_file": None,
+        "runner": None,
+        "runner_target": None,
+        "input": None,
+        "period": 0.10,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_command_wants_runner_live():
+    assert _command_wants_runner(_ns(cmd="live")) is True
+
+
+def test_command_wants_runner_record():
+    assert _command_wants_runner(_ns(cmd="record")) is True
+
+
+def test_command_wants_runner_replay_never():
+    assert _command_wants_runner(_ns(cmd="replay")) is False
+
+
+def test_command_wants_runner_dump_with_input_no():
+    assert _command_wants_runner(_ns(cmd="dump", input="x.gz")) is False
+
+
+def test_command_wants_runner_dump_without_input_yes():
+    assert _command_wants_runner(_ns(cmd="dump", input=None)) is True
+
+
 @pytest.fixture
 def fake_build_dir(tmp_path, monkeypatch):
-    """tmp_path with a populated build/zephyr/zephyr.elf and runners.yaml."""
+    """``tmp_path`` with ``build/zephyr/zephyr.elf`` + ``runners.yaml`` populated."""
     build = tmp_path / "build" / "zephyr"
     build.mkdir(parents=True)
     elf = build / "zephyr.elf"
@@ -94,125 +74,79 @@ def fake_build_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def test_inject_elf_when_missing_uses_build_path(fake_build_dir):
+def test_fill_elf_when_missing_uses_build_path(fake_build_dir):
     cmd = _make_cmd()
-    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
+    args = _ns()
+    cmd._fill_elf(args)
+    assert args.elf_file == str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
 
-    out = cmd._inject_elf_if_missing(["live"])
-    assert out == ["live", "-e", expected]
 
-
-def test_inject_elf_at_front_when_no_command(fake_build_dir):
-    """No command present → ELF flag goes at the front (becomes implicit live)."""
+def test_fill_elf_skips_when_explicit(fake_build_dir):
     cmd = _make_cmd()
-    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
-
-    out = cmd._inject_elf_if_missing([])
-    assert out == ["-e", expected]
-
-
-def test_inject_elf_keeps_command_at_front_with_other_flags(fake_build_dir):
-    """The verb stays at argv[0]; -e is inserted just after it."""
-    cmd = _make_cmd()
-    expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
-
-    out = cmd._inject_elf_if_missing(["dump", "--json"])
-    assert out == ["dump", "-e", expected, "--json"]
+    args = _ns(elf_file="/custom/path.elf")
+    cmd._fill_elf(args)
+    assert args.elf_file == "/custom/path.elf"
 
 
-def test_inject_elf_skips_when_e_present(fake_build_dir):
-    cmd = _make_cmd()
-    out = cmd._inject_elf_if_missing(["live", "-e", "/custom/path.elf"])
-    assert out == ["live", "-e", "/custom/path.elf"]
-
-
-def test_inject_elf_skips_when_long_form_present(fake_build_dir):
-    cmd = _make_cmd()
-    out = cmd._inject_elf_if_missing(["--elf-file=/x.elf", "live"])
-    assert out == ["--elf-file=/x.elf", "live"]
-
-
-def test_inject_elf_skips_when_help_requested(tmp_path, monkeypatch):
-    """No build dir, but --help must still pass through without dying."""
+def test_fill_elf_dies_when_build_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     cmd = _make_cmd()
-    out = cmd._inject_elf_if_missing(["--help"])
-    assert out == ["--help"]
-
-
-def test_inject_elf_dies_when_build_missing(tmp_path, monkeypatch):
-    """No build dir and no --help → log.die must be invoked."""
-    monkeypatch.chdir(tmp_path)
-    cmd = _make_cmd()
+    args = _ns()
     with pytest.raises(SystemExit):
-        cmd._inject_elf_if_missing(["live"])
+        cmd._fill_elf(args)
 
 
-# --- Runner injection ---
-
-
-def test_inject_runner_for_live(fake_build_dir):
+def test_fill_runner_for_live(fake_build_dir):
     cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["live"])
-    assert out == ["live", "-r", "jlink", "-t", "nRF5340_xxAA"]
+    args = _ns(cmd="live")
+    cmd._fill_runner(args)
+    assert args.runner == "jlink"
+    assert args.runner_target == "nRF5340_xxAA"
 
 
-def test_inject_runner_for_record(fake_build_dir):
+def test_fill_runner_for_record(fake_build_dir):
     cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["record", "-o", "x.gz", "--frames", "1"])
-    # Verb stays at argv[0]; -r/-t inserted right after.
-    assert out[0] == "record"
-    assert out[1:5] == ["-r", "jlink", "-t", "nRF5340_xxAA"]
-    assert out[5:] == ["-o", "x.gz", "--frames", "1"]
+    args = _ns(cmd="record")
+    cmd._fill_runner(args)
+    assert args.runner == "jlink"
+    assert args.runner_target == "nRF5340_xxAA"
 
 
-def test_inject_runner_keeps_dump_command_at_front(fake_build_dir):
-    """Regression: dump --json must not have -r/-t injected before the verb."""
+def test_fill_runner_skips_when_both_explicit(fake_build_dir):
     cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["dump", "--json"])
-    assert out[0] == "dump"
-    assert "-r" in out and "-t" in out
-    assert out.index("-r") > 0  # not at front
+    args = _ns(cmd="live", runner="pyocd", runner_target="stm32h753zitx")
+    cmd._fill_runner(args)
+    assert args.runner == "pyocd"
+    assert args.runner_target == "stm32h753zitx"
 
 
-def test_inject_runner_skips_replay(fake_build_dir):
+def test_fill_runner_fills_only_missing_target(fake_build_dir):
     cmd = _make_cmd()
-    argv = ["replay", "-i", "x.gz"]
-    out = cmd._inject_runner_if_missing(argv)
-    assert out == argv
+    args = _ns(cmd="live", runner="jlink", runner_target=None)
+    cmd._fill_runner(args)
+    assert args.runner == "jlink"  # untouched
+    assert args.runner_target == "nRF5340_xxAA"
 
 
-def test_inject_runner_skips_dump_with_input(fake_build_dir):
+def test_parser_bare_invocation_defaults_to_live():
     cmd = _make_cmd()
-    argv = ["dump", "-i", "x.gz", "--json"]
-    out = cmd._inject_runner_if_missing(argv)
-    assert out == argv
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    parser = cmd.do_add_parser(subparsers)
+    args = parser.parse_args([])
+    assert args.cmd == "live"
+    assert args.elf_file is None
+    assert args.runner is None
+    assert args.runner_target is None
 
 
-def test_inject_runner_for_dump_without_input(fake_build_dir):
+def test_parser_dump_command_parses_input_and_json():
     cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["dump", "--json"])
-    assert "-r" in out and "-t" in out
-
-
-def test_inject_runner_skips_when_both_present(fake_build_dir):
-    cmd = _make_cmd()
-    argv = ["live", "-r", "pyocd", "-t", "stm32h753zitx"]
-    out = cmd._inject_runner_if_missing(argv)
-    assert out == argv  # no duplication
-
-
-def test_inject_runner_fills_only_missing_target(fake_build_dir):
-    """Runner explicit, target missing → only -t injected."""
-    cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["live", "-r", "jlink"])
-    # -t injected, -r untouched. The user's explicit "-r jlink" is preserved.
-    assert "-t" in out
-    assert out.count("-r") == 1
-
-
-def test_inject_runner_skips_when_help_requested(fake_build_dir):
-    cmd = _make_cmd()
-    out = cmd._inject_runner_if_missing(["live", "--help"])
-    assert out == ["live", "--help"]
-    # Specifically: no runners.yaml read attempted.
+    subparsers = argparse.ArgumentParser().add_subparsers()
+    parser = cmd.do_add_parser(subparsers)
+    args = parser.parse_args(["dump", "-i", "x.gz", "--json"])
+    assert args.cmd == "dump"
+    assert args.input == "x.gz"
+    assert args.json is True
+    # Auto-filled fields stay None at parse time:
+    assert args.elf_file is None
+    assert args.runner is None

--- a/tests/test_west_command.py
+++ b/tests/test_west_command.py
@@ -10,6 +10,7 @@ not importable.
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -72,6 +73,14 @@ def test_help_requested_short_long():
 # --- ELF injection ---
 
 
+def _make_cmd() -> ZViewCommand:
+    """ZViewCommand with the minimal config that die/err/wrn need outside a west session."""
+    cmd = ZViewCommand()
+    cmd.config = MagicMock()
+    cmd.config.getboolean.return_value = False
+    return cmd
+
+
 @pytest.fixture
 def fake_build_dir(tmp_path, monkeypatch):
     """tmp_path with a populated build/zephyr/zephyr.elf and runners.yaml."""
@@ -86,7 +95,7 @@ def fake_build_dir(tmp_path, monkeypatch):
 
 
 def test_inject_elf_when_missing_uses_build_path(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     expected = str(fake_build_dir / "build" / "zephyr" / "zephyr.elf")
 
     out = cmd._inject_elf_if_missing(["live"])
@@ -112,13 +121,13 @@ def test_inject_elf_keeps_command_at_front_with_other_flags(fake_build_dir):
 
 
 def test_inject_elf_skips_when_e_present(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_elf_if_missing(["live", "-e", "/custom/path.elf"])
     assert out == ["live", "-e", "/custom/path.elf"]
 
 
 def test_inject_elf_skips_when_long_form_present(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_elf_if_missing(["--elf-file=/x.elf", "live"])
     assert out == ["--elf-file=/x.elf", "live"]
 
@@ -126,7 +135,7 @@ def test_inject_elf_skips_when_long_form_present(fake_build_dir):
 def test_inject_elf_skips_when_help_requested(tmp_path, monkeypatch):
     """No build dir, but --help must still pass through without dying."""
     monkeypatch.chdir(tmp_path)
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_elf_if_missing(["--help"])
     assert out == ["--help"]
 
@@ -134,7 +143,7 @@ def test_inject_elf_skips_when_help_requested(tmp_path, monkeypatch):
 def test_inject_elf_dies_when_build_missing(tmp_path, monkeypatch):
     """No build dir and no --help → log.die must be invoked."""
     monkeypatch.chdir(tmp_path)
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     with pytest.raises(SystemExit):
         cmd._inject_elf_if_missing(["live"])
 
@@ -143,13 +152,13 @@ def test_inject_elf_dies_when_build_missing(tmp_path, monkeypatch):
 
 
 def test_inject_runner_for_live(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_runner_if_missing(["live"])
     assert out == ["live", "-r", "jlink", "-t", "nRF5340_xxAA"]
 
 
 def test_inject_runner_for_record(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_runner_if_missing(["record", "-o", "x.gz", "--frames", "1"])
     # Verb stays at argv[0]; -r/-t inserted right after.
     assert out[0] == "record"
@@ -167,27 +176,27 @@ def test_inject_runner_keeps_dump_command_at_front(fake_build_dir):
 
 
 def test_inject_runner_skips_replay(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     argv = ["replay", "-i", "x.gz"]
     out = cmd._inject_runner_if_missing(argv)
     assert out == argv
 
 
 def test_inject_runner_skips_dump_with_input(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     argv = ["dump", "-i", "x.gz", "--json"]
     out = cmd._inject_runner_if_missing(argv)
     assert out == argv
 
 
 def test_inject_runner_for_dump_without_input(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_runner_if_missing(["dump", "--json"])
     assert "-r" in out and "-t" in out
 
 
 def test_inject_runner_skips_when_both_present(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     argv = ["live", "-r", "pyocd", "-t", "stm32h753zitx"]
     out = cmd._inject_runner_if_missing(argv)
     assert out == argv  # no duplication
@@ -195,7 +204,7 @@ def test_inject_runner_skips_when_both_present(fake_build_dir):
 
 def test_inject_runner_fills_only_missing_target(fake_build_dir):
     """Runner explicit, target missing → only -t injected."""
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_runner_if_missing(["live", "-r", "jlink"])
     # -t injected, -r untouched. The user's explicit "-r jlink" is preserved.
     assert "-t" in out
@@ -203,7 +212,7 @@ def test_inject_runner_fills_only_missing_target(fake_build_dir):
 
 
 def test_inject_runner_skips_when_help_requested(fake_build_dir):
-    cmd = ZViewCommand()
+    cmd = _make_cmd()
     out = cmd._inject_runner_if_missing(["live", "--help"])
     assert out == ["live", "--help"]
     # Specifically: no runners.yaml read attempted.

--- a/tests/test_z_scraper.py
+++ b/tests/test_z_scraper.py
@@ -86,7 +86,9 @@ def test_poll_thread_worker_math_and_queue(elf_path):
     scraper.has_usage = True
     scraper.idle_threads_address = 0x2000
 
-    scraper._offsets = {"thread_info": {"usage": 0x10}}
+    from dataclasses import replace as dc_replace
+
+    scraper._layout = dc_replace(scraper._layout, thread_usage=0x10)
     scraper._cpu_usage_address = 0x1000
     scraper.last_cpu_cycles = 100
     scraper.last_cpu_delta = 100

--- a/tests/test_z_scraper.py
+++ b/tests/test_z_scraper.py
@@ -16,7 +16,7 @@ from orchestrator import ZScraper
 
 
 def test_gdb_scraper_endianness():
-    """Validates that GDBScraper correctly applies endianness to struct unpacking."""
+    """``GDBScraper`` applies endianness to struct unpacking."""
     scraper = GDBScraper("localhost:1234")
     scraper._read_mem_raw = MagicMock()
 
@@ -38,7 +38,7 @@ def test_gdb_scraper_endianness():
 
 
 def test_pyocd_scraper_read64_endianness():
-    """Validates the struct unpacking of 64-bit words in PyOCDScraper."""
+    """``PyOCDScraper.read64`` unpacks with endianness."""
     scraper = PyOCDScraper(None)
     scraper.target = MagicMock()
 
@@ -76,7 +76,7 @@ def elf_path():
 
 
 def test_poll_thread_worker_math_and_queue(elf_path):
-    """Validates CPU normalization and watermark percentage calculation via queue emission."""
+    """CPU normalization and watermark percentage propagate to the emitted frame."""
 
     mock_meta_scraper = MagicMock()
     mock_meta_scraper.is_connected = True
@@ -146,7 +146,7 @@ def test_poll_thread_worker_math_and_queue(elf_path):
 
 
 def _make_strike_scraper(elf_path):
-    """ZScraper shim with has_usage/has_heaps disabled; exercises the read path cleanly."""
+    """``ZScraper`` shim with ``has_usage``/``has_heaps`` disabled."""
     mock = MagicMock()
     mock.is_connected = True
     scraper = ZScraper(mock, elf_path=elf_path, max_threads=2)
@@ -160,7 +160,7 @@ def _make_strike_scraper(elf_path):
 
 
 def test_single_strike_emits_transient_error(elf_path):
-    """A single read failure emits a transient error and does not stop the loop."""
+    """One read failure emits a transient error; loop continues."""
     scraper, mock = _make_strike_scraper(elf_path)
     mock.calculate_dynamic_watermark.side_effect = RuntimeError("read fail")
 
@@ -177,7 +177,7 @@ def test_single_strike_emits_transient_error(elf_path):
 
 
 def test_three_strikes_emit_fatal_and_break(elf_path):
-    """Three consecutive failures emit a fatal_error and terminate the loop."""
+    """Three consecutive failures emit ``fatal_error`` and terminate the loop."""
     scraper, mock = _make_strike_scraper(elf_path)
     mock.calculate_dynamic_watermark.side_effect = RuntimeError("persistent fail")
 
@@ -200,7 +200,7 @@ def test_three_strikes_emit_fatal_and_break(elf_path):
 
 
 def test_strike_counter_resets_on_success(elf_path):
-    """Two failures followed by success reset the counter; no fatal_error emitted."""
+    """Two failures + one success resets the counter; no ``fatal_error``."""
     scraper, mock = _make_strike_scraper(elf_path)
     mock.calculate_dynamic_watermark.side_effect = [
         RuntimeError("fail-1"),
@@ -233,7 +233,7 @@ def test_strike_counter_resets_on_success(elf_path):
 
 
 def test_queue_full_is_not_counted_as_strike(elf_path):
-    """queue.Full on put is silently swallowed; no strike is recorded."""
+    """``queue.Full`` is swallowed; not counted as a strike."""
     scraper, mock = _make_strike_scraper(elf_path)
     mock.calculate_dynamic_watermark.return_value = 250
 
@@ -263,7 +263,7 @@ def test_queue_full_is_not_counted_as_strike(elf_path):
 
 
 def test_reset_runtime_state_clears_caches_and_rebaselines(elf_path):
-    """Wipes watermark_cache + last_thread_cycles and re-reads init_cpu_cycles."""
+    """Clears ``watermark_cache``/``last_thread_cycles``; re-reads ``init_cpu_cycles``."""
     scraper = ZScraper.__new__(ZScraper)
     mock = MagicMock()
     mock.watermark_cache = {0x1000: 100, 0x2000: 200}
@@ -289,7 +289,7 @@ def test_reset_runtime_state_clears_caches_and_rebaselines(elf_path):
 
 
 def test_reset_runtime_state_without_usage_only_clears_watermark(elf_path):
-    """With has_usage=False, reset_runtime_state clears watermark_cache and returns early."""
+    """``has_usage=False``: ``reset_runtime_state`` clears watermark only and exits early."""
     scraper = ZScraper.__new__(ZScraper)
     mock = MagicMock()
     mock.watermark_cache = {0x1000: 100}


### PR DESCRIPTION
This PR adds a wrapper class to enable current scrappers recording and redirecting of sessions

It includes a new way of using ZView: subcommands. The current default is still the live TUI session, but you may now:
- `record` for a given number of frames or seconds;
- `replay` a given recorded file
- `dump` a given frame of data from a live/recorded session

This also hardens the architecture of the codebase, removing some found smells and bad patterns