### PR TITLE
Explicitly require dependencies minimum versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ name = "zview"
 version = "0.11.0"
 authors = [{ name = "Paulo Santos", email = "pauloxrms@gmail.com" }]
 description = "ZView, a Zephyr RTOS runtime visualizer"
-dependencies = ["PyYAML", "pyelftools", "pyocd", "pylink-square"]
+dependencies = [
+  "PyYAML>=6.0.3",
+  "pyelftools>=0.32",
+  "pyocd>=0.38.0",
+  "pylink-square>=1.7.0",
+]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML
-pyelftools
-pyocd
-pylink-square
+PyYAML>=6.0.3
+pyelftools>=0.32
+pyocd>=0.38.0
+pylink-square>=1.7.0

--- a/src/backend/pyocd.py
+++ b/src/backend/pyocd.py
@@ -70,4 +70,4 @@ class PyOCDScraper(AbstractScraper):
             raise ProbeReadFailure("No target available.")
 
         raw_bytes = bytes(self.target.read_memory_block8(at, amount * 8))
-        return struct.unpack(f'{self.endianess}{amount}Q', raw_bytes)
+        return struct.unpack(f"{self.endianess}{amount}Q", raw_bytes)


### PR DESCRIPTION
It has been noticed some misbehaviors with ZView running over older versions of `pyocd`/`pylink-square`. This sets the lowerbound for scraper backend versions so that use becomes reliable across users.

Noticibly buggy versions for `pyocd` are `0.37.0` and bellow