### PR TITLE
Add thread extra information to detail view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zview"
-version = "0.11.0"
+version = "0.12.0"
 authors = [{ name = "Paulo Santos", email = "pauloxrms@gmail.com" }]
 description = "ZView, a Zephyr RTOS runtime visualizer"
 dependencies = [

--- a/src/backend/base.py
+++ b/src/backend/base.py
@@ -50,6 +50,32 @@ class ThreadRuntime:
     stack_watermark_percent: float
 
 
+# Zephyr ``_THREAD_*`` state bit constants from ``include/zephyr/kernel.h``;
+# stable across versions. Decoding is "first match wins" against this priority
+# list so the most informative state is reported when bits overlap.
+_THREAD_STATE_BITS: tuple[tuple[int, str], ...] = (
+    (0x01, "dummy"),
+    (0x08, "dead"),
+    (0x20, "aborting"),
+    (0x10, "suspended"),
+    (0x02, "pending"),
+    (0x04, "prestart"),
+    (0x80, "queued"),
+)
+
+
+def decode_thread_state(state: int | None) -> str | None:
+    """Map a ``thread_state`` bitfield to the most informative single-word label."""
+    if state is None:
+        return None
+    if state == 0:
+        return "running"
+    for bit, label in _THREAD_STATE_BITS:
+        if state & bit:
+            return label
+    return f"unknown(0x{state:02x})"
+
+
 @dataclass(frozen=True)
 class ThreadInfo:
     """Static identity and stack geometry of a Zephyr thread plus its latest runtime."""
@@ -59,6 +85,11 @@ class ThreadInfo:
     stack_size: int
     name: str
     runtime: ThreadRuntime | None
+    priority: int | None = None
+    state: int | None = None
+    user_options: int | None = None
+    entry_point: int | None = None
+    entry_symbol: str | None = None
 
 
 @dataclass(frozen=True)
@@ -78,7 +109,7 @@ class AbstractScraper(ABC):
     """Common interface for memory-read backends (JLink, pyOCD, GDB RSP)."""
 
     # True for live probe backends; False for synthetic backends (replay) that
-    # cannot accept runtime mutations — no reconnect, no change to the polling
+    # cannot accept runtime mutations - no reconnect, no change to the polling
     # shape (thread pool, heap fragmentation toggle) mid-stream. Subclasses that
     # cannot absorb such mutations must set this to False.
     is_live: bool = True

--- a/src/backend/base.py
+++ b/src/backend/base.py
@@ -50,32 +50,6 @@ class ThreadRuntime:
     stack_watermark_percent: float
 
 
-# Zephyr ``_THREAD_*`` state bit constants from ``include/zephyr/kernel.h``;
-# stable across versions. Decoding is "first match wins" against this priority
-# list so the most informative state is reported when bits overlap.
-_THREAD_STATE_BITS: tuple[tuple[int, str], ...] = (
-    (0x01, "dummy"),
-    (0x08, "dead"),
-    (0x20, "aborting"),
-    (0x10, "suspended"),
-    (0x02, "pending"),
-    (0x04, "prestart"),
-    (0x80, "queued"),
-)
-
-
-def decode_thread_state(state: int | None) -> str | None:
-    """Map a ``thread_state`` bitfield to the most informative single-word label."""
-    if state is None:
-        return None
-    if state == 0:
-        return "running"
-    for bit, label in _THREAD_STATE_BITS:
-        if state & bit:
-            return label
-    return f"unknown(0x{state:02x})"
-
-
 @dataclass(frozen=True)
 class ThreadInfo:
     """Static identity and stack geometry of a Zephyr thread plus its latest runtime."""

--- a/src/backend/elf_inspector.py
+++ b/src/backend/elf_inspector.py
@@ -26,6 +26,8 @@ from elftools.elf.sections import SymbolTableSection
 _CACHE_HMAC_KEY = hashlib.sha256(str(Path.home()).encode()).digest()
 _HMAC_SIZE = 32  # SHA-256 digest length in bytes
 
+_CACHE_SCHEMA_VERSION = 2
+
 
 class ElfInspector:
     """
@@ -85,7 +87,7 @@ class ElfInspector:
         Any change to the ELF or the interpreter invalidates the cache.
         """
         stats = self._path.stat()
-        return (stats.st_mtime, stats.st_size, sys.hexversion)
+        return (stats.st_mtime, stats.st_size, sys.hexversion, _CACHE_SCHEMA_VERSION)
 
     def _load_cache(self) -> bool:
         """
@@ -178,6 +180,43 @@ class ElfInspector:
         except OSError:
             tmp.unlink(missing_ok=True)
 
+    def _collect_members(self, parent_die, struct_name: str, base_offset: int) -> None:
+        """Walk ``parent_die`` recording each ``DW_TAG_member``.
+
+        Anonymous members whose type is itself a struct or union are flattened:
+        their inner members are folded into ``struct_name`` at the parent's
+        offset. This is what makes ``_thread_base.prio`` resolvable when ``prio``
+        sits inside an anonymous union+struct in Zephyr's headers.
+        """
+        for child in parent_die.iter_children():
+            if child.tag != "DW_TAG_member":
+                continue
+            loc_attr = child.attributes.get("DW_AT_data_member_location")
+            if loc_attr is None:
+                # Union members elide the location attribute (offset is 0).
+                child_loc = 0
+            else:
+                child_loc = (
+                    loc_attr.value[1] if loc_attr.form == "DW_FORM_exprloc" else loc_attr.value
+                )
+            full_loc = base_offset + child_loc
+
+            m_name_attr = child.attributes.get("DW_AT_name")
+            if m_name_attr:
+                m_name = m_name_attr.value.decode(errors="ignore")
+                self._struct_members[struct_name][m_name] = full_loc
+                continue
+
+            # Anonymous member: descend into its type if it's a struct/union.
+            if "DW_AT_type" not in child.attributes:
+                continue
+            try:
+                type_die = child.get_DIE_from_attribute("DW_AT_type")
+            except Exception:
+                continue
+            if type_die.tag in ("DW_TAG_structure_type", "DW_TAG_union_type"):
+                self._collect_members(type_die, struct_name, full_loc)
+
     def _perform_single_pass_scan(self):
         """
         Executes a sweep of the ELF and DWARF tree.
@@ -224,19 +263,7 @@ class ElfInspector:
                             self._struct_sizes[struct_name] = size_attr.value
 
                         self._struct_members.setdefault(struct_name, {})
-
-                        for child in die.iter_children():
-                            if child.tag == "DW_TAG_member":
-                                m_name_attr = child.attributes.get("DW_AT_name")
-                                loc_attr = child.attributes.get("DW_AT_data_member_location")
-                                if m_name_attr and loc_attr:
-                                    m_name = m_name_attr.value.decode(errors="ignore")
-                                    loc = (
-                                        loc_attr.value[1]
-                                        if loc_attr.form == "DW_FORM_exprloc"
-                                        else loc_attr.value
-                                    )
-                                    self._struct_members[struct_name][m_name] = loc
+                        self._collect_members(die, struct_name, base_offset=0)
 
                     elif die.tag == "DW_TAG_variable":
                         name_attr = die.attributes.get("DW_AT_name")
@@ -274,15 +301,23 @@ class ElfInspector:
             raise ValueError(f"Invalid info type: {info}")
 
     def get_symbol_name_at(self, addr: int) -> str | None:
-        """Reverse symbol lookup. Returns the symbol whose address matches ``addr``."""
+        """Reverse symbol lookup. Returns the symbol whose address matches ``addr``.
+
+        Keys are stored with the Thumb bit cleared (Cortex-M function symbols
+        carry an odd ``st_value`` which would otherwise miss every lookup).
+        ARM mapping symbols (``$t``/``$a``/``$d``/``$x``) are skipped so they
+        don't shadow real function symbols at the same address.
+        """
         cache = getattr(self, "_address_to_symbol", None)
         if cache is None:
             cache = {}
             for name, addrs in self._symbols_address.items():
+                if name.startswith("$"):
+                    continue
                 for a in addrs:
-                    cache.setdefault(a, name)
+                    cache.setdefault(a & ~1, name)
             self._address_to_symbol = cache
-        return cache.get(addr)
+        return cache.get(addr & ~1)
 
     def get_struct_member_offset(self, struct_name: str, member_name: str) -> int:
         """

--- a/src/backend/elf_inspector.py
+++ b/src/backend/elf_inspector.py
@@ -21,8 +21,8 @@ from typing import Literal
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import SymbolTableSection
 
-# HMAC key derived from the user's home directory — machine-specific,
-# makes tampered cache files detectable across machines.
+# HMAC key derived from the user's home directory: machine-specific, makes
+# tampered cache files detectable across machines.
 _CACHE_HMAC_KEY = hashlib.sha256(str(Path.home()).encode()).digest()
 _HMAC_SIZE = 32  # SHA-256 digest length in bytes
 
@@ -273,6 +273,17 @@ class ElfInspector:
         else:
             raise ValueError(f"Invalid info type: {info}")
 
+    def get_symbol_name_at(self, addr: int) -> str | None:
+        """Reverse symbol lookup. Returns the symbol whose address matches ``addr``."""
+        cache = getattr(self, "_address_to_symbol", None)
+        if cache is None:
+            cache = {}
+            for name, addrs in self._symbols_address.items():
+                for a in addrs:
+                    cache.setdefault(a, name)
+            self._address_to_symbol = cache
+        return cache.get(addr)
+
     def get_struct_member_offset(self, struct_name: str, member_name: str) -> int:
         """
         Returns the byte offset of a named member within a named struct.
@@ -302,7 +313,7 @@ class ElfInspector:
 
         The returned list is deduplicated (a symbol appearing in multiple
         compilation units is reported only once) and preserves DWARF
-        discovery order — critical for downstream consumers (ZScraper's
+        discovery order: critical for downstream consumers (ZScraper's
         polling loop, recording/replay lockstep) that depend on a stable
         iteration order across processes.
         """

--- a/src/backend/gdb.py
+++ b/src/backend/gdb.py
@@ -124,8 +124,8 @@ class GDBScraper(AbstractScraper):
         """
         Receive one RSP response packet and return its payload.
 
-        Strips leading ``+`` ack bytes and the ``$…#cc`` framing. Raises
-        ``socket.timeout`` on receive deadline — callers that treat a missing
+        Strips leading ``+`` ack bytes and the ``$...#cc`` framing. Raises
+        ``socket.timeout`` on receive deadline; callers that treat a missing
         reply as non-fatal should catch it explicitly.
         """
         if self.sock is None:

--- a/src/backend/replay.py
+++ b/src/backend/replay.py
@@ -27,7 +27,7 @@ class ReplayExhausted(ReplayError):
 
 
 class ReplayComplete(ReplayError):
-    """Caller attempted a new frame past the trailing disconnect — the recording ended cleanly."""
+    """Caller attempted a new frame past the trailing disconnect: the recording ended cleanly."""
 
 
 class UnsupportedSchema(ReplayError):
@@ -95,7 +95,7 @@ class ReplayScraper(AbstractScraper):
         entry = self._entries[self._cursor]
 
         # A caller starting a new frame while the cursor sits on the trailing
-        # ``disconnect`` entry means the recording has been fully consumed —
+        # ``disconnect`` entry means the recording has been fully consumed:
         # that's a clean end-of-stream, not a drift.
         if op == "begin_batch" and entry["op"] == "disconnect":
             raise ReplayComplete(f"Recording ended cleanly at index {self._cursor}.")

--- a/src/frontend/tui/views/thread_detail.py
+++ b/src/frontend/tui/views/thread_detail.py
@@ -4,7 +4,7 @@
 
 import curses
 
-from backend.base import ThreadInfo, decode_thread_state
+from backend.base import ThreadInfo
 from frontend.tui.views.base import (
     Any,
     BaseStateView,
@@ -15,28 +15,36 @@ from frontend.tui.views.base import (
     compute_flex_widths,
 )
 from frontend.tui.views.thread_list import ThreadListView
-from frontend.tui.widgets import TUIGraph, TUIThreadInfo
+from frontend.tui.widgets import TUIBox, TUIGraph, TUIThreadInfo
 
 
-def _format_thread_meta(thread: ThreadInfo) -> str:
-    """One-line shell-style metadata: ``prio | state | options | entry``."""
-    parts: list[str] = []
-    if thread.priority is not None:
-        parts.append(f"prio: {thread.priority}")
-    state_label = decode_thread_state(thread.state)
-    if state_label is not None:
-        parts.append(f"state: {state_label}")
-    if thread.user_options is not None:
-        parts.append(f"options: 0x{thread.user_options:02x}")
-    if thread.entry_point:
-        if thread.entry_symbol:
-            parts.append(f"entry: {thread.entry_symbol} (0x{thread.entry_point:08x})")
-        else:
-            parts.append(f"entry: 0x{thread.entry_point:08x}")
-    return " | ".join(parts)
+def _format_priority(thread: ThreadInfo) -> str:
+    return str(thread.priority) if thread.priority is not None else "-"
+
+
+def _format_options(thread: ThreadInfo) -> str:
+    return f"0x{thread.user_options:02x}" if thread.user_options is not None else "-"
+
+
+def _format_entry(thread: ThreadInfo) -> str:
+    if not thread.entry_point:
+        return "-"
+    if thread.entry_symbol:
+        return f"{thread.entry_symbol} (0x{thread.entry_point:08x})"
+    return f"0x{thread.entry_point:08x}"
 
 
 class ThreadDetailView(BaseStateView):
+    _INFO_BOX_HEIGHT = 3
+
+    # ``(title, weight, formatter)``: weight is the relative horizontal share
+    # used when laying the boxes side-by-side; entry needs the most room.
+    _INFO_BOXES: tuple[tuple[str, int, Any], ...] = (
+        ("Priority", 1, _format_priority),
+        ("Options", 1, _format_options),
+        ("Entry", 3, _format_entry),
+    )
+
     def __init__(self, controller: Any, theme: ZViewTUIAttributes):
         super().__init__(controller, theme)
         self._cpu_graph: TUIGraph = TUIGraph(
@@ -45,6 +53,9 @@ class ThreadDetailView(BaseStateView):
         self._load_graph: TUIGraph = TUIGraph(
             "Load %", "Thread cycles / Non-idle cycles", (0, 100), theme.GRAPH_A
         )
+        self._info_widgets: list[TUIBox] = [
+            TUIBox(title, "", theme.GRAPH_B) for title, _, _ in self._INFO_BOXES
+        ]
 
         self._scheme: dict[str, int] = ThreadListView.SCHEMA
         bar_theme = (theme.PROGRESS_BAR_LOW, theme.PROGRESS_BAR_MEDIUM, theme.PROGRESS_BAR_HIGH)
@@ -60,6 +71,27 @@ class ThreadDetailView(BaseStateView):
         )
         self._current_thread_name: str | None = None
         self._usages: dict[str, list[int]] = {"cpu": [], "load": []}
+
+    def _draw_info_boxes(
+        self, stdscr: curses.window, y: int, width: int, thread: ThreadInfo
+    ) -> None:
+        """Lay the identity boxes side-by-side, sized by their relative weights."""
+        weights = [w for _, w, _ in self._INFO_BOXES]
+        total_weight = sum(weights)
+        x = 0
+        for idx, ((title, weight, fmt), box) in enumerate(
+            zip(self._INFO_BOXES, self._info_widgets, strict=True)
+        ):
+            del title  # unused here; widgets carry their own titles
+            # The last box takes any rounding remainder so the row ends flush at ``width``.
+            is_last = idx == len(self._INFO_BOXES) - 1
+            box_w = (width - x) if is_last else (width * weight) // total_weight
+            box.draw(stdscr, y, x, self._INFO_BOX_HEIGHT, box_w)
+            value = fmt(thread)
+            inner_w = box_w - 4  # 2 border cells + 2 padding cells
+            if inner_w > 0:
+                stdscr.addstr(y + 1, x + 2, value.ljust(inner_w)[:inner_w])
+            x += box_w
 
     def render(self, stdscr: curses.window, height: int, width: int) -> None:
         stdscr.erase()
@@ -96,15 +128,16 @@ class ThreadDetailView(BaseStateView):
 
         self._tui_thread_info.draw(stdscr, 2, 0, thread)
 
-        meta_line = _format_thread_meta(thread)
-        if meta_line:
-            stdscr.addstr(3, 0, meta_line[: width - 1])
+        info_top = 3
+        self._draw_info_boxes(stdscr, info_top, width, thread)
 
         self._usages["cpu"].append(int(thread.runtime.cpu_normalized))
         self._usages["load"].append(int(thread.runtime.cpu))
 
-        graph_top = 5 if meta_line else 4
-        graph_height = max(self.controller.min_dimensions[0] - 6, height - 3 - graph_top)
+        graph_top = info_top + self._INFO_BOX_HEIGHT
+        graph_height = max(
+            self.controller.min_dimensions[0] - 5 - self._INFO_BOX_HEIGHT, height - 3 - graph_top
+        )
         graph_width = width // 2
 
         if len(self._usages["load"]) > graph_width - 2:

--- a/src/frontend/tui/views/thread_detail.py
+++ b/src/frontend/tui/views/thread_detail.py
@@ -4,6 +4,7 @@
 
 import curses
 
+from backend.base import ThreadInfo, decode_thread_state
 from frontend.tui.views.base import (
     Any,
     BaseStateView,
@@ -15,6 +16,24 @@ from frontend.tui.views.base import (
 )
 from frontend.tui.views.thread_list import ThreadListView
 from frontend.tui.widgets import TUIGraph, TUIThreadInfo
+
+
+def _format_thread_meta(thread: ThreadInfo) -> str:
+    """One-line shell-style metadata: ``prio | state | options | entry``."""
+    parts: list[str] = []
+    if thread.priority is not None:
+        parts.append(f"prio: {thread.priority}")
+    state_label = decode_thread_state(thread.state)
+    if state_label is not None:
+        parts.append(f"state: {state_label}")
+    if thread.user_options is not None:
+        parts.append(f"options: 0x{thread.user_options:02x}")
+    if thread.entry_point:
+        if thread.entry_symbol:
+            parts.append(f"entry: {thread.entry_symbol} (0x{thread.entry_point:08x})")
+        else:
+            parts.append(f"entry: 0x{thread.entry_point:08x}")
+    return " | ".join(parts)
 
 
 class ThreadDetailView(BaseStateView):
@@ -77,21 +96,24 @@ class ThreadDetailView(BaseStateView):
 
         self._tui_thread_info.draw(stdscr, 2, 0, thread)
 
+        meta_line = _format_thread_meta(thread)
+        if meta_line:
+            stdscr.addstr(3, 0, meta_line[: width - 1])
+
         self._usages["cpu"].append(int(thread.runtime.cpu_normalized))
         self._usages["load"].append(int(thread.runtime.cpu))
 
-        graph_height = max(self.controller.min_dimensions[0] - 6, height - 7)
+        graph_top = 5 if meta_line else 4
+        graph_height = max(self.controller.min_dimensions[0] - 6, height - 3 - graph_top)
         graph_width = width // 2
 
         if len(self._usages["load"]) > graph_width - 2:
             self._usages["load"].pop(0)
             self._usages["cpu"].pop(0)
 
-        y = 4
-
         self._cpu_graph.draw(
             stdscr,
-            y,
+            graph_top,
             0,
             graph_height,
             graph_width,
@@ -100,7 +122,7 @@ class ThreadDetailView(BaseStateView):
 
         self._load_graph.draw(
             stdscr,
-            y,
+            graph_top,
             graph_width,
             graph_height,
             graph_width,

--- a/src/frontend/tui/widgets.py
+++ b/src/frontend/tui/widgets.py
@@ -13,7 +13,7 @@ def _truncate_str(text: str, max_size: int) -> str:
 
 
 def _fit_str(text: str, width: int, align: str = "^") -> str:
-    """Pad ``text`` to ``width`` (``align`` ∈ ``^<>``), then hard-clip to ``width``."""
+    """Pad ``text`` to ``width`` (``align`` is one of ``^<>``), then hard-clip to ``width``."""
     return f"{text:{align}{width}}"[:width]
 
 

--- a/src/frontend/zview_tui.py
+++ b/src/frontend/zview_tui.py
@@ -268,7 +268,7 @@ class ZView:
             return
 
         if data.get("replay_complete"):
-            self.status_message = "Recording ended — replay complete."
+            self.status_message = "Recording ended; replay complete."
             return
 
         if data.get("error"):

--- a/src/kernel/layout.py
+++ b/src/kernel/layout.py
@@ -22,7 +22,13 @@ class KernelLayout:
 
     # Optional: per-thread CPU usage (CONFIG_THREAD_RUNTIME_STATS)
     cpu_usage: int | None = None  # z_kernel.usage
-    thread_usage: int | None = None  # k_thread → k_cycle_stats.total
+    thread_usage: int | None = None  # k_thread -> k_cycle_stats.total
+
+    # Optional: thread metadata mirroring `kernel threads list` shell output.
+    thread_priority: int | None = None  # k_thread.base.prio (signed 8-bit)
+    thread_state: int | None = None  # k_thread.base.thread_state (8-bit bitfield)
+    thread_user_options: int | None = None  # k_thread.base.user_options
+    thread_entry: int | None = None  # k_thread.entry.pEntry (function pointer)
 
     # Optional: heap stats (CONFIG_SYS_HEAP_RUNTIME_STATS)
     heap_free_bytes: int | None = None

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -90,6 +90,9 @@ class ZScraper:
         else:
             self.has_heaps = False
 
+        if (extras := self._try_resolve_thread_meta()) is not None:
+            fields.update(extras)
+
         return KernelLayout(**fields)
 
     def _try_resolve_thread_name(self) -> dict | None:
@@ -109,6 +112,26 @@ class ZScraper:
         except LookupError:
             return None
         return {"cpu_usage": cpu_usage, "thread_usage": thread_usage}
+
+    def _try_resolve_thread_meta(self) -> dict | None:
+        """Resolve ``k_thread`` metadata mirroring ``kernel threads list`` shell output."""
+        elf = self._elf_inspector
+        try:
+            base = elf.get_struct_member_offset("k_thread", "base")
+        except LookupError:
+            return None
+        out: dict = {}
+        for layout_field, member in (
+            ("thread_priority", "prio"),
+            ("thread_state", "thread_state"),
+            ("thread_user_options", "user_options"),
+        ):
+            with contextlib.suppress(LookupError):
+                out[layout_field] = base + elf.get_struct_member_offset("_thread_base", member)
+        with contextlib.suppress(LookupError):
+            entry = elf.get_struct_member_offset("k_thread", "entry")
+            out["thread_entry"] = entry + elf.get_struct_member_offset("_thread_entry", "pEntry")
+        return out or None
 
     def _try_resolve_heaps(self) -> dict | None:
         elf = self._elf_inspector
@@ -365,6 +388,8 @@ class ZScraper:
                 (watermark / thread.stack_size * 100) if thread.stack_size > 0 else 0.0
             )
 
+            meta = self._read_thread_meta(thread)
+
             polled.append(
                 {
                     "info": thread,
@@ -372,10 +397,56 @@ class ZScraper:
                     "is_active": is_active,
                     "watermark": watermark,
                     "stack_usage_pct": stack_usage_pct,
+                    "meta": meta,
                 }
             )
 
         return polled, cpu_cycles_delta
+
+    def _read_thread_meta(self, thread: ThreadInfo) -> dict:
+        """Read priority/state/options/entry for a thread; missing offsets yield ``None``."""
+        meta: dict = {
+            "priority": None,
+            "state": None,
+            "user_options": None,
+            "entry_point": None,
+            "entry_symbol": None,
+        }
+        layout = self._layout
+        scraper = self._m_scraper
+        try:
+            if layout.thread_priority is not None:
+                raw = scraper.read8(thread.address + layout.thread_priority)[0]
+                meta["priority"] = raw - 256 if raw >= 0x80 else raw  # signed 8-bit
+            if layout.thread_state is not None:
+                meta["state"] = scraper.read8(thread.address + layout.thread_state)[0]
+            if layout.thread_user_options is not None:
+                meta["user_options"] = scraper.read8(thread.address + layout.thread_user_options)[0]
+            if layout.thread_entry is not None:
+                entry = scraper.read32(thread.address + layout.thread_entry)[0]
+                meta["entry_point"] = entry
+                meta["entry_symbol"] = self._resolve_entry_symbol(entry)
+        except Exception:
+            # Per-frame read fault on metadata is non-fatal: leave fields ``None``.
+            pass
+        return meta
+
+    def _resolve_entry_symbol(self, addr: int) -> str | None:
+        """Cache-backed reverse symbol lookup for a function pointer."""
+        if addr == 0:
+            return None
+        cache = getattr(self, "_entry_symbol_cache", None)
+        if cache is None:
+            self._entry_symbol_cache = cache = {}
+        if addr in cache:
+            return cache[addr]
+        # Thumb code pointers have bit 0 set; mask before lookup.
+        try:
+            sym = self._elf_inspector.get_symbol_name_at(addr & ~1)
+        except Exception:
+            sym = None
+        cache[addr] = sym
+        return sym
 
     def _finalize_threads(self, polled: list[dict], cpu_cycles_delta: int) -> list[ThreadInfo]:
         """Build ``ThreadInfo`` objects from raw polling state, computing CPU% and load%."""
@@ -405,6 +476,7 @@ class ZScraper:
                 stack_watermark=data["watermark"],
                 stack_watermark_percent=data["stack_usage_pct"],
             )
+            meta = data.get("meta") or {}
             final.append(
                 ThreadInfo(
                     address=data["info"].address,
@@ -412,6 +484,11 @@ class ZScraper:
                     stack_size=data["info"].stack_size,
                     name=data["info"].name,
                     runtime=runtime,
+                    priority=meta.get("priority"),
+                    state=meta.get("state"),
+                    user_options=meta.get("user_options"),
+                    entry_point=meta.get("entry_point"),
+                    entry_symbol=meta.get("entry_symbol"),
                 )
             )
         return final

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -130,7 +130,14 @@ class ZScraper:
                 out[layout_field] = base + elf.get_struct_member_offset("_thread_base", member)
         with contextlib.suppress(LookupError):
             entry = elf.get_struct_member_offset("k_thread", "entry")
-            out["thread_entry"] = entry + elf.get_struct_member_offset("_thread_entry", "pEntry")
+            # Struct name is ``__thread_entry`` in current Zephyr; some older
+            # vendor trees may have used a single underscore.
+            for entry_struct in ("__thread_entry", "_thread_entry"):
+                with contextlib.suppress(LookupError):
+                    out["thread_entry"] = entry + elf.get_struct_member_offset(
+                        entry_struct, "pEntry"
+                    )
+                    break
         return out or None
 
     def _try_resolve_heaps(self) -> dict | None:

--- a/src/zview_cli.py
+++ b/src/zview_cli.py
@@ -72,7 +72,7 @@ def register_commands(
     """
     Add the live/record/replay/dump subparsers to ``sub``.
     Flag names listed in ``auto_filled`` ({"elf", "target"}) are declared
-    non-required. ``subcommand_epilogs`` maps command name → epilog text.
+    non-required. ``subcommand_epilogs`` maps command name -> epilog text.
     """
     epilogs = subcommand_epilogs or {}
     elf_required = "elf" not in auto_filled

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,7 +231,7 @@ def test_record_forwards_heap_flag(monkeypatch, capsys, tmp_path):
 
 
 def test_replay_no_pacing_passes_to_scraper(monkeypatch, capsys):
-    """--no-pacing → ReplayScraper(honor_timing=False)."""
+    """--no-pacing -> ReplayScraper(honor_timing=False)."""
     captured: dict = {}
     real_cls = zview_cli.ReplayScraper
 

--- a/tests/test_heap_detail_helpers.py
+++ b/tests/test_heap_detail_helpers.py
@@ -23,7 +23,7 @@ def test_sparsity_map_zero_total_bytes_returns_empty():
 
 
 def test_sparsity_map_all_used_renders_full_blocks():
-    """Single fully-used chunk must produce only ``█``."""
+    """Single fully-used chunk must produce only the full-block glyph."""
     chunks = [{"size": 100, "used": True}]
     rows = HeapDetailView.get_sparsity_map(chunks, 10, 1)
     assert rows == ["█" * 10]

--- a/tests/test_replay_integration.py
+++ b/tests/test_replay_integration.py
@@ -91,7 +91,7 @@ def test_thread_shape(replay_run):
 
 
 def test_heap_shape(replay_run):
-    """Emitted heaps report non-negative sizes; max ≥ allocated."""
+    """Emitted heaps report non-negative sizes; max >= allocated."""
     frames, _ = replay_run
     last = _last_valid_frame(frames)
     heaps: list[HeapInfo] = last.get("heaps", [])

--- a/tests/test_snapshot_roundtrip.py
+++ b/tests/test_snapshot_roundtrip.py
@@ -88,7 +88,7 @@ def test_dump_single_frame_via_replay():
 
 
 def test_record_session_roundtrip(tmp_path):
-    """ReplayScraper → RecordingScraper produces a replayable recording."""
+    """ReplayScraper -> RecordingScraper produces a replayable recording."""
     source = ReplayScraper(_FIXTURE, honor_timing=False)
     out_path = tmp_path / "roundtrip.ndjson.gz"
 
@@ -96,7 +96,7 @@ def test_record_session_roundtrip(tmp_path):
     assert out_path.exists()
     assert captured >= 1
 
-    # Replay the recorded session — it must yield at least one valid frame.
+    # Replay the recorded session: it must yield at least one valid frame.
     replay2 = ReplayScraper(out_path, honor_timing=False)
     frame2 = dump_single_frame(replay2, str(_ELF), period=0.001, timeout=3.0)
     assert "threads" in frame2

--- a/tests/test_tui_views.py
+++ b/tests/test_tui_views.py
@@ -29,7 +29,7 @@ def controller() -> MagicMock:
 
 
 def test_thread_list_footer_truncates_at_max_with_ellipsis(controller, theme):
-    """5 view bindings -> ``Help: ?`` prepended, top 3 shown, trailing ``…``."""
+    """5 view bindings -> ``Help: ?`` prepended, top 3 shown, trailing overflow indicator."""
     view = ThreadListView(controller, theme)
     hint = view._footer_hint().rstrip()
     parts = [p.strip() for p in hint.split("|")]
@@ -39,7 +39,7 @@ def test_thread_list_footer_truncates_at_max_with_ellipsis(controller, theme):
 
 
 def test_heap_list_footer_overflow(controller, theme):
-    """4 view bindings overflow the cap of 3 -> trailing ``…``."""
+    """4 view bindings overflow the cap of 3 -> trailing overflow indicator."""
     view = HeapListView(controller, theme)
     hint = view._footer_hint().rstrip()
     parts = [p.strip() for p in hint.split("|")]
@@ -72,7 +72,7 @@ def test_fit_str_pads_when_shorter():
 
 
 def test_fit_str_truncates_when_longer():
-    """Hard-clip the formatted string at exactly ``width`` — never spill over."""
+    """Hard-clip the formatted string at exactly ``width``; never spill over."""
     from frontend.tui.widgets import _fit_str
 
     assert _fit_str("1234567890", 4) == "1234"
@@ -137,7 +137,7 @@ def test_compute_flex_widths_grows_name_only_as_needed():
 
 
 def test_compute_flex_widths_caps_name_at_actual_need():
-    """Once name is satisfied, leftover goes to bar — name never exceeds longest item."""
+    """Once name is satisfied, leftover goes to bar; name never exceeds longest item."""
     from frontend.tui.views.base import compute_flex_widths
 
     items = [_Named("x" * 36)]

--- a/tests/test_z_scraper.py
+++ b/tests/test_z_scraper.py
@@ -244,7 +244,7 @@ def test_queue_full_is_not_counted_as_strike(elf_path):
     stop_event = threading.Event()
 
     # Run a single frame; time.sleep stops the loop. If queue.Full were a strike,
-    # a transient error message would be appended here — but the queue is full so
+    # a transient error message would be appended here, but the queue is full so
     # nothing gets appended regardless. The real assertion is that no fatal_error
     # fires even across many iterations.
     iterations = [0]
@@ -257,7 +257,7 @@ def test_queue_full_is_not_counted_as_strike(elf_path):
     with patch("time.sleep", side_effect=fake_sleep):
         scraper._poll_thread_worker(q, stop_event, 0)
 
-    # Queue still holds only the sentinel — no transient or fatal_error emitted.
+    # Queue still holds only the sentinel: no transient or fatal_error emitted.
     assert q.get_nowait() == {"sentinel": True}
     assert q.empty()
 


### PR DESCRIPTION
Closes #5 (finnaly :P)

Thread state has been intentionally kept out from the view, since the snapshots are more confusing than helping. Since the each frame is a snapshot read, often the snapshot cant reflect the true state of the thread, and seeing it active (has ran since last frame) while the state never changes from `pending`, let's say, is very misleading.

It may be helpful to now that a thread is not dead, but this can be also achieved bu refreshing the kernel list (by pressing `r` on the list view) and activity is clear from the graphs. This may be rolledback.

This adds `Prioriry`, `Options` and `Entry` information for a given thread. Other Informations may be added later if the need arrives and they are collectable from the scraper side.