### PR TITLE
feat(jlink): add -s/--serial-number to select probe by S/N

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ZView is invoked through one of four commands. Bare `zview ...` is a shortcut fo
 | `-e, --elf-file` | all | Path to the firmware `.elf` file (e.g. `build/zephyr/zephyr.elf`). |
 | `-r, --runner` | `live`, `record`, `dump` | Debug runner: `jlink`, `pyocd`, or `gdb`. |
 | `-t, --runner-target` | `live`, `record`, `dump` | MCU descriptor for the chosen runner (see below). |
+| `-s, --serial-number` | `live`, `record`, `dump` | J-Link probe serial number. Bypasses the interactive probe-selection dialog when multiple J-Link probes are connected. |
 | `--period` | `live`, `record`, `dump` | Polling period in seconds (default: `0.10`). |
 
 ### Command-specific arguments
@@ -108,6 +109,10 @@ Use the device name from the [J-Link Supported Devices list](https://www.segger.
 ```
 # Example: Nordic nRF5340 DK
 west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA
+
+# With multiple probes connected, pass the S/N to skip the selection dialog
+# (get serial numbers with: nrfutil device list)
+west zview -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA -s <jlink-serial-number>
 ```
 
 **pyOCD (`-r pyocd`)**

--- a/src/backend/jlink.py
+++ b/src/backend/jlink.py
@@ -12,8 +12,9 @@ from backend.base import AbstractScraper, ProbeConnectFailure
 
 
 class JLinkScraper(AbstractScraper):
-    def __init__(self, target_mcu: str | None):
+    def __init__(self, target_mcu: str | None, serial_number: int | None = None):
         super().__init__(target_mcu)
+        self._serial_number = serial_number
         self.probe = JLink()
 
     def connect(self):
@@ -21,7 +22,7 @@ class JLinkScraper(AbstractScraper):
             return
 
         try:
-            self.probe.open()
+            self.probe.open(serial_no=self._serial_number)
         except JLinkException as e:
             raise ProbeConnectFailure(f"Unable to open JLink probe: {e}") from e
 

--- a/src/zview_cli.py
+++ b/src/zview_cli.py
@@ -52,6 +52,15 @@ def _add_live_target(parser: argparse.ArgumentParser, *, required: bool = True) 
         default=None,
         help="MCU descriptor for the chosen runner.",
     )
+    parser.add_argument(
+        "-s",
+        "--serial-number",
+        dest="serial_number",
+        type=int,
+        default=None,
+        metavar="SERIAL",
+        help="J-Link probe serial number (avoids the probe-selection dialog when multiple probes are connected).",
+    )
 
 
 def _add_period(parser: argparse.ArgumentParser) -> None:
@@ -189,6 +198,9 @@ def _build_live_backend(args):
         "pyocd": PyOCDScraper,
     }
     cls = scraper_map.get(args.runner, PyOCDScraper)
+    serial_number = getattr(args, "serial_number", None)
+    if cls is JLinkScraper:
+        return cls(args.runner_target, serial_number=serial_number)
     return cls(args.runner_target)
 
 


### PR DESCRIPTION
Without serial_no, JLink.open() raises an interactive probe-selection dialog when more than one J-Link probe is connected. The new flag passes the serial number directly to pylink's JLink.open(serial_no=...), which bypasses the dialog entirely.

Example usage:
  west zview live -e build/zephyr/zephyr.elf -r jlink -t nRF5340_xxAA -s <jlink-serial-number>

Get serial numbers with: nrfutil device list