### PR TITLE
Harden pool timing fidelity for `record` command 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zview"
-version = "0.13.0"
+version = "0.13.1"
 authors = [{ name = "Paulo Santos", email = "pauloxrms@gmail.com" }]
 description = "ZView, a Zephyr RTOS runtime visualizer"
 dependencies = [

--- a/src/backend/recording.py
+++ b/src/backend/recording.py
@@ -49,10 +49,10 @@ class RecordingScraper(AbstractScraper):
         self._fp.write(json.dumps(header) + "\n")
 
     def _emit(self, op: str, args: dict, result=None) -> None:
-        """Append one call entry: ``{t, op, args[, result]}``."""
+        """Append one call entry: ``{t, op, args[, result]}``. ``t`` is monotonic."""
         if self._fp is None:
             return
-        entry: dict = {"t": time.time(), "op": op, "args": args}
+        entry: dict = {"t": time.perf_counter(), "op": op, "args": args}
         if result is not None:
             entry["result"] = result
         self._fp.write(json.dumps(entry) + "\n")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -286,6 +286,7 @@ class ZScraper:
 
         consecutive_errors = 0
         while not stop_event.is_set():
+            cycle_start = time.perf_counter()
             in_batch = False
             try:
                 self._m_scraper.begin_batch()
@@ -331,7 +332,11 @@ class ZScraper:
                     with contextlib.suppress(Exception):
                         self._m_scraper.end_batch()
 
-            time.sleep(inspection_period)
+            # Sleep only the remainder of the period, so the poll cadence tracks
+            # the requested period instead of period-plus-read-time. When the
+            # reads already exceed the period, poll back-to-back (no sleep).
+            elapsed = time.perf_counter() - cycle_start
+            time.sleep(max(0.0, inspection_period - elapsed))
 
     def _read_cpu_cycles_delta(self) -> int:
         """Cycles elapsed since the last frame; ``-1`` when ``has_usage`` is False."""


### PR DESCRIPTION
Recording often caused the requested pediod to be added to reading time, causing less frames than expected to be captured. Make the sleep timer acount for time spent reading the target.