### PR TITLE
Add Zephyr compatibility layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zview"
-version = "0.13.1"
+version = "0.14.0"
 authors = [{ name = "Paulo Santos", email = "pauloxrms@gmail.com" }]
 description = "ZView, a Zephyr RTOS runtime visualizer"
 dependencies = [

--- a/src/kernel/compat.py
+++ b/src/kernel/compat.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Zephyr kernel offset and Kconfig compatibility tables.
+
+Field offsets are read from DWARF at runtime. This module holds the candidate
+member paths for each logical field, the Kconfig probes and the Zephyr version
+lookup.
+
+``resolve_offset`` tries candidate paths in order, summing the steps of a path,
+so a field reached through a sub-struct such as ``k_mem_slab.info.num_used`` is
+one entry. ``has_kconfig`` reads the ``CONFIG_*`` absolute symbols from the ELF
+symbol table. ``detect_zephyr_version`` reads ``KERNEL_VERSION_STRING`` from the
+build tree.
+
+The tables match the struct definitions in Zephyr v3.0.0, v3.3.0, v3.7.0,
+v4.0.0 and v4.4.0. Where a field has more than one candidate, the comment names
+the release that differs.
+"""
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from backend.elf_inspector import ElfInspector
+
+# A member path whose per-step offsets are summed: (("k_mem_slab", "info"),
+# ("k_mem_slab_info", "num_used")) resolves a field inside a sub-struct.
+MemberPath = Sequence[tuple[str, str]]
+FieldTable = dict[str, tuple[MemberPath, ...]]
+
+CONFIG_WAITQ_SIMPLE = "CONFIG_WAITQ_SIMPLE"
+CONFIG_WAITQ_SCALABLE = "CONFIG_WAITQ_SCALABLE"
+
+WaitQFlavor = Literal["simple", "scalable", "unknown"]
+
+_VERSION_HEADER = Path("include") / "generated" / "zephyr" / "version.h"
+_VERSION_PATTERN = re.compile(r'#define\s+KERNEL_VERSION_STRING\s+"([^"]+)"')
+_VERSION_SEARCH_DEPTH = 4
+
+# --- Threads -----------------------------------------------------------------
+
+# Required for thread walking.
+THREAD_FIELDS: FieldTable = {
+    "threads_head": ((("z_kernel", "threads"),),),
+    "thread_next": ((("k_thread", "next_thread"),),),
+    "stack_start": ((("k_thread", "stack_info"), ("_thread_stack_info", "start")),),
+    "stack_size": ((("k_thread", "stack_info"), ("_thread_stack_info", "size")),),
+}
+
+# CONFIG_THREAD_NAME.
+THREAD_NAME_FIELDS: FieldTable = {
+    "thread_name": ((("k_thread", "name"),),),
+}
+
+# CONFIG_THREAD_RUNTIME_STATS. z_kernel.usage exists from v3.7.0; on v3.0 and
+# v3.3 this group does not resolve.
+USAGE_FIELDS: FieldTable = {
+    "cpu_usage": ((("z_kernel", "usage"),),),
+    "thread_usage": (
+        (("k_thread", "base"), ("_thread_base", "usage"), ("k_cycle_stats", "total")),
+    ),
+}
+
+# Metadata mirroring `kernel threads list`. Resolved individually.
+THREAD_META_FIELDS: FieldTable = {
+    "thread_priority": ((("k_thread", "base"), ("_thread_base", "prio")),),
+    "thread_state": ((("k_thread", "base"), ("_thread_base", "thread_state")),),
+    "thread_user_options": ((("k_thread", "base"), ("_thread_base", "user_options")),),
+    "thread_entry": (
+        (("k_thread", "entry"), ("__thread_entry", "pEntry")),
+        # Single-underscore struct name carried by some vendor trees.
+        (("k_thread", "entry"), ("_thread_entry", "pEntry")),
+    ),
+}
+
+# Wait queues hold ``_thread_base.qnode_dlist`` nodes; a thread address is a
+# node address minus this offset.
+THREAD_QNODE_FIELDS: FieldTable = {
+    "thread_qnode": ((("k_thread", "base"), ("_thread_base", "qnode_dlist")),),
+}
+
+# --- Heaps -------------------------------------------------------------------
+
+# CONFIG_SYS_HEAP_RUNTIME_STATS. max_allocated_bytes exists from v3.3.0; on
+# v3.0 this group does not resolve.
+HEAP_FIELDS: FieldTable = {
+    "heap_free_bytes": ((("z_heap", "free_bytes"),),),
+    "heap_allocated_bytes": ((("z_heap", "allocated_bytes"),),),
+    "heap_max_allocated_bytes": ((("z_heap", "max_allocated_bytes"),),),
+    "heap_end_chunk": ((("z_heap", "end_chunk"),),),
+}
+
+# --- Synchronization primitives ----------------------------------------------
+
+SEMAPHORE_FIELDS: FieldTable = {
+    "sem_wait_q": ((("k_sem", "wait_q"),),),
+    "sem_count": ((("k_sem", "count"),),),
+    "sem_limit": ((("k_sem", "limit"),),),
+}
+
+MUTEX_FIELDS: FieldTable = {
+    "mutex_wait_q": ((("k_mutex", "wait_q"),),),
+    "mutex_owner": ((("k_mutex", "owner"),),),
+    "mutex_lock_count": ((("k_mutex", "lock_count"),),),
+}
+
+MSGQ_FIELDS: FieldTable = {
+    "msgq_wait_q": ((("k_msgq", "wait_q"),),),
+    "msgq_msg_size": ((("k_msgq", "msg_size"),),),
+    "msgq_max_msgs": ((("k_msgq", "max_msgs"),),),
+    "msgq_used_msgs": ((("k_msgq", "used_msgs"),),),
+}
+
+EVENT_FIELDS: FieldTable = {
+    "event_wait_q": ((("k_event", "wait_q"),),),
+    "event_events": ((("k_event", "events"),),),
+}
+
+# The counters moved into a ``k_mem_slab_info`` sub-struct in v3.7.0; v3.0 and
+# v3.3 carry them directly on k_mem_slab.
+MEM_SLAB_FIELDS: FieldTable = {
+    "mem_slab_wait_q": ((("k_mem_slab", "wait_q"),),),
+    "mem_slab_num_blocks": (
+        (("k_mem_slab", "info"), ("k_mem_slab_info", "num_blocks")),
+        (("k_mem_slab", "num_blocks"),),
+    ),
+    "mem_slab_block_size": (
+        (("k_mem_slab", "info"), ("k_mem_slab_info", "block_size")),
+        (("k_mem_slab", "block_size"),),
+    ),
+    "mem_slab_num_used": (
+        (("k_mem_slab", "info"), ("k_mem_slab_info", "num_used")),
+        (("k_mem_slab", "num_used"),),
+    ),
+}
+
+# CONFIG_MEM_SLAB_TRACE_MAX_UTILIZATION, and only inside the sub-struct layout.
+MEM_SLAB_OPTIONAL_FIELDS: FieldTable = {
+    "mem_slab_max_used": ((("k_mem_slab", "info"), ("k_mem_slab_info", "max_used")),),
+}
+
+# k_work has no wait queue; pending work sits on its queue's list.
+WORK_FIELDS: FieldTable = {
+    "work_handler": ((("k_work", "handler"),),),
+    "work_queue": ((("k_work", "queue"),),),
+    "work_flags": ((("k_work", "flags"),),),
+}
+
+
+@dataclass(frozen=True)
+class ObjectSpec:
+    """A kernel object type, its C struct, and the fields needed to read it."""
+
+    label: str
+    struct: str
+    fields: FieldTable
+    optional_fields: FieldTable | None = None
+
+
+# Kernel object types and the fields needed to read them. Instances are found
+# by searching DWARF for globals of ``struct``, so only statically declared
+# objects appear.
+KERNEL_OBJECTS: dict[str, ObjectSpec] = {
+    "semaphores": ObjectSpec("SEM", "k_sem", SEMAPHORE_FIELDS),
+    "mutexes": ObjectSpec("MTX", "k_mutex", MUTEX_FIELDS),
+    "msgqs": ObjectSpec("MSG", "k_msgq", MSGQ_FIELDS),
+    "events": ObjectSpec("EVT", "k_event", EVENT_FIELDS),
+    "mem_slabs": ObjectSpec("SLB", "k_mem_slab", MEM_SLAB_FIELDS, MEM_SLAB_OPTIONAL_FIELDS),
+    "work": ObjectSpec("WRK", "k_work", WORK_FIELDS),
+}
+
+
+def resolve_offset(elf: ElfInspector, candidates: Sequence[MemberPath]) -> int | None:
+    """
+    Return the offset of the first candidate path this ELF resolves.
+
+    Every step of a path must resolve for that path to match. Returns ``None``
+    when no candidate resolves.
+    """
+    for path in candidates:
+        offset = 0
+        for struct_name, member in path:
+            try:
+                offset += elf.get_struct_member_offset(struct_name, member)
+            except LookupError:
+                break
+        else:
+            return offset
+
+    return None
+
+
+def resolve_fields(elf: ElfInspector, fields: FieldTable) -> dict[str, int] | None:
+    """
+    Resolve a whole field group.
+
+    Returns ``None`` if any member is missing; a group never resolves
+    partially.
+    """
+    resolved: dict[str, int] = {}
+    for name, candidates in fields.items():
+        offset = resolve_offset(elf, candidates)
+        if offset is None:
+            return None
+        resolved[name] = offset
+
+    return resolved
+
+
+def resolve_optional_fields(elf: ElfInspector, fields: FieldTable) -> dict[str, int]:
+    """
+    Resolve the members of a group this ELF has, skipping the rest.
+
+    For groups whose fields are independent, such as the thread metadata.
+    """
+    resolved: dict[str, int] = {}
+    for name, candidates in fields.items():
+        offset = resolve_offset(elf, candidates)
+        if offset is not None:
+            resolved[name] = offset
+
+    return resolved
+
+
+def has_kconfig(elf: ElfInspector, option: str) -> bool:
+    """
+    Report whether a Kconfig option was enabled in the build.
+
+    Zephyr emits each enabled ``CONFIG_*`` as an absolute symbol; a disabled
+    option is absent from the symbol table.
+    """
+    try:
+        elf.get_symbol_info(option, "address")
+    except LookupError:
+        return False
+
+    return True
+
+
+def waitq_flavor(elf: ElfInspector) -> WaitQFlavor:
+    """
+    Report the ``_wait_q_t`` layout this build uses.
+
+    ``simple`` is a ``sys_dlist_t``, ``scalable`` a red-black tree
+    (``struct _priq_rb``). Only ``simple`` is walkable. ``unknown`` means the
+    build advertises neither and is treated as not walkable.
+    """
+    if has_kconfig(elf, CONFIG_WAITQ_SIMPLE):
+        return "simple"
+    if has_kconfig(elf, CONFIG_WAITQ_SCALABLE):
+        return "scalable"
+
+    return "unknown"
+
+
+def detect_zephyr_version(elf_path: Path | str) -> str | None:
+    """
+    Return ``KERNEL_VERSION_STRING`` for an ELF inside its build tree.
+
+    Reads ``<build>/zephyr/include/generated/zephyr/version.h``, looked up
+    beside the ELF and a few directories up. Returns ``None`` for an ELF
+    outside a build tree.
+    """
+    elf = Path(elf_path)
+    try:
+        elf = elf.resolve()
+    except OSError:
+        return None
+
+    for base in (elf.parent, *list(elf.parents)[:_VERSION_SEARCH_DEPTH]):
+        header = base / _VERSION_HEADER
+        try:
+            if not header.is_file():
+                continue
+            match = _VERSION_PATTERN.search(header.read_text())
+        except OSError:
+            continue
+
+        if match:
+            return match.group(1)
+
+    return None

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -15,6 +15,7 @@ from typing import Literal
 from backend.base import AbstractScraper, HeapInfo, ThreadInfo, ThreadRuntime
 from backend.elf_inspector import ElfInspector
 from backend.replay import ReplayComplete
+from kernel import compat
 from kernel.heaps import walk_heap_fragmentation
 from kernel.layout import KernelLayout
 from kernel.threads import walk_thread_list
@@ -70,93 +71,30 @@ class ZScraper:
     def _resolve_layout(self) -> KernelLayout:
         """Resolve DWARF-derived offsets. Sets ``has_*`` flags for missing features."""
         elf = self._elf_inspector
-        stack_info = elf.get_struct_member_offset("k_thread", "stack_info")
 
-        fields: dict = {
-            "threads_head": elf.get_struct_member_offset("z_kernel", "threads"),
-            "thread_next": elf.get_struct_member_offset("k_thread", "next_thread"),
-            "stack_start": stack_info + elf.get_struct_member_offset("_thread_stack_info", "start"),
-            "stack_size": stack_info + elf.get_struct_member_offset("_thread_stack_info", "size"),
-        }
+        thread_fields = compat.resolve_fields(elf, compat.THREAD_FIELDS)
+        if thread_fields is None:
+            raise LookupError(
+                "Kernel thread layout not found in the ELF. ZView needs a build with "
+                "CONFIG_THREAD_MONITOR=y and CONFIG_THREAD_STACK_INFO=y."
+            )
 
-        if (extras := self._try_resolve_thread_name()) is not None:
-            fields.update(extras)
-        else:
-            self.has_names = False
+        fields: dict = dict(thread_fields)
 
-        if (extras := self._try_resolve_usage()) is not None:
-            fields.update(extras)
-        else:
-            self.has_usage = False
+        for group, flag in (
+            (compat.THREAD_NAME_FIELDS, "has_names"),
+            (compat.USAGE_FIELDS, "has_usage"),
+            (compat.HEAP_FIELDS, "has_heaps"),
+        ):
+            if (extras := compat.resolve_fields(elf, group)) is not None:
+                fields.update(extras)
+            else:
+                setattr(self, flag, False)
 
-        if (extras := self._try_resolve_heaps()) is not None:
-            fields.update(extras)
-        else:
-            self.has_heaps = False
-
-        if (extras := self._try_resolve_thread_meta()) is not None:
-            fields.update(extras)
+        # Metadata members resolve independently.
+        fields.update(compat.resolve_optional_fields(elf, compat.THREAD_META_FIELDS))
 
         return KernelLayout(**fields)
-
-    def _try_resolve_thread_name(self) -> dict | None:
-        try:
-            return {"thread_name": self._elf_inspector.get_struct_member_offset("k_thread", "name")}
-        except LookupError:
-            return None
-
-    def _try_resolve_usage(self) -> dict | None:
-        elf = self._elf_inspector
-        try:
-            cpu_usage = elf.get_struct_member_offset("z_kernel", "usage")
-            usage_base = elf.get_struct_member_offset(
-                "k_thread", "base"
-            ) + elf.get_struct_member_offset("_thread_base", "usage")
-            thread_usage = usage_base + elf.get_struct_member_offset("k_cycle_stats", "total")
-        except LookupError:
-            return None
-        return {"cpu_usage": cpu_usage, "thread_usage": thread_usage}
-
-    def _try_resolve_thread_meta(self) -> dict | None:
-        """Resolve ``k_thread`` metadata mirroring ``kernel threads list`` shell output."""
-        elf = self._elf_inspector
-        try:
-            base = elf.get_struct_member_offset("k_thread", "base")
-        except LookupError:
-            return None
-        out: dict = {}
-        for layout_field, member in (
-            ("thread_priority", "prio"),
-            ("thread_state", "thread_state"),
-            ("thread_user_options", "user_options"),
-        ):
-            with contextlib.suppress(LookupError):
-                out[layout_field] = base + elf.get_struct_member_offset("_thread_base", member)
-        with contextlib.suppress(LookupError):
-            entry = elf.get_struct_member_offset("k_thread", "entry")
-            # Struct name is ``__thread_entry`` in current Zephyr; some older
-            # vendor trees may have used a single underscore.
-            for entry_struct in ("__thread_entry", "_thread_entry"):
-                with contextlib.suppress(LookupError):
-                    out["thread_entry"] = entry + elf.get_struct_member_offset(
-                        entry_struct, "pEntry"
-                    )
-                    break
-        return out or None
-
-    def _try_resolve_heaps(self) -> dict | None:
-        elf = self._elf_inspector
-        try:
-            return {
-                "heap_free_bytes": elf.get_struct_member_offset("z_heap", "free_bytes"),
-                "heap_allocated_bytes": elf.get_struct_member_offset("z_heap", "allocated_bytes"),
-                "heap_max_allocated_bytes": elf.get_struct_member_offset(
-                    "z_heap", "max_allocated_bytes"
-                ),
-                "heap_end_chunk": elf.get_struct_member_offset("z_heap", "end_chunk"),
-            }
-        except LookupError:
-            return None
 
     def _resolve_addresses(self) -> None:
         elf = self._elf_inspector

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 Paulo Santos (@wkhadgar)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from kernel import compat
+
+
+class FakeElf:
+    """ElfInspector stand-in with a fixed member table and symbol set."""
+
+    def __init__(self, members: dict[tuple[str, str], int], symbols: tuple[str, ...] = ()):
+        self._members = members
+        self._symbols = set(symbols)
+
+    def get_struct_member_offset(self, struct_name: str, member: str) -> int:
+        try:
+            return self._members[(struct_name, member)]
+        except KeyError as e:
+            raise LookupError(f"{struct_name}.{member}") from e
+
+    def get_symbol_info(self, symbol_name: str, info: str) -> list[int]:
+        if symbol_name not in self._symbols:
+            raise LookupError(symbol_name)
+        return [1]
+
+
+def test_resolve_offset_takes_the_first_matching_candidate():
+    elf = FakeElf({("k_msgq", "used_msgs"): 24, ("k_msgq", "used"): 99})
+
+    offset = compat.resolve_offset(elf, ((("k_msgq", "used_msgs"),), (("k_msgq", "used"),)))
+
+    assert offset == 24
+
+
+def test_resolve_offset_falls_through_to_a_later_candidate():
+    """A renamed member resolves through the next candidate."""
+    elf = FakeElf({("k_msgq", "used"): 99})
+
+    offset = compat.resolve_offset(elf, ((("k_msgq", "used_msgs"),), (("k_msgq", "used"),)))
+
+    assert offset == 99
+
+
+def test_resolve_offset_sums_a_nested_path():
+    """k_mem_slab moved its counters into an ``info`` sub-struct."""
+    elf = FakeElf({("k_mem_slab", "info"): 16, ("k_mem_slab_info", "num_used"): 8})
+
+    offset = compat.resolve_offset(
+        elf, ((("k_mem_slab", "info"), ("k_mem_slab_info", "num_used")),)
+    )
+
+    assert offset == 24
+
+
+def test_partially_resolvable_path_is_rejected():
+    """A path with a missing step does not resolve."""
+    elf = FakeElf({("k_mem_slab", "info"): 16})
+
+    offset = compat.resolve_offset(
+        elf, ((("k_mem_slab", "info"), ("k_mem_slab_info", "num_used")),)
+    )
+
+    assert offset is None
+
+
+def test_resolve_offset_without_any_candidate():
+    assert compat.resolve_offset(FakeElf({}), ((("k_sem", "count"),),)) is None
+
+
+def test_resolve_fields_is_all_or_nothing():
+    """A group with a missing member resolves to None."""
+    elf = FakeElf({("k_sem", "wait_q"): 0, ("k_sem", "count"): 8})
+
+    assert compat.resolve_fields(elf, compat.SEMAPHORE_FIELDS) is None
+
+
+def test_resolve_fields_returns_the_whole_group():
+    elf = FakeElf({("k_sem", "wait_q"): 0, ("k_sem", "count"): 8, ("k_sem", "limit"): 12})
+
+    assert compat.resolve_fields(elf, compat.SEMAPHORE_FIELDS) == {
+        "sem_wait_q": 0,
+        "sem_count": 8,
+        "sem_limit": 12,
+    }
+
+
+def test_has_kconfig_reads_the_absolute_symbols():
+    """Zephyr emits every enabled CONFIG_* as an absolute symbol."""
+    elf = FakeElf({}, symbols=("CONFIG_THREAD_NAME",))
+
+    assert compat.has_kconfig(elf, "CONFIG_THREAD_NAME")
+    assert not compat.has_kconfig(elf, "CONFIG_THREAD_RUNTIME_STATS")
+
+
+def test_waitq_flavor_simple():
+    elf = FakeElf({}, symbols=(compat.CONFIG_WAITQ_SIMPLE,))
+
+    assert compat.waitq_flavor(elf) == "simple"
+
+
+def test_waitq_flavor_scalable():
+    elf = FakeElf({}, symbols=(compat.CONFIG_WAITQ_SCALABLE,))
+
+    assert compat.waitq_flavor(elf) == "scalable"
+
+
+def test_waitq_flavor_unknown_is_not_walkable():
+    """A build advertising neither option reports unknown."""
+    assert compat.waitq_flavor(FakeElf({})) == "unknown"
+
+
+def _write_version_header(build_dir: Path, version: str) -> Path:
+    generated = build_dir / "include" / "generated" / "zephyr"
+    generated.mkdir(parents=True)
+    (generated / "version.h").write_text(
+        "#define ZEPHYR_VERSION_CODE 263168\n"
+        f'#define KERNEL_VERSION_STRING           "{version}"\n'
+    )
+    return build_dir
+
+
+def test_detect_zephyr_version_beside_the_elf(tmp_path: Path):
+    build = _write_version_header(tmp_path / "zephyr", "4.4.99")
+    elf = build / "zephyr.elf"
+    elf.write_bytes(b"")
+
+    assert compat.detect_zephyr_version(elf) == "4.4.99"
+
+
+def test_detect_zephyr_version_from_a_nested_elf(tmp_path: Path):
+    """The header sits a few directories up from some build layouts."""
+    build = _write_version_header(tmp_path / "build" / "zephyr", "4.3.0")
+    nested = build / "sub" / "dir"
+    nested.mkdir(parents=True)
+    elf = nested / "zephyr.elf"
+    elf.write_bytes(b"")
+
+    assert compat.detect_zephyr_version(elf) == "4.3.0"
+
+
+def test_detect_zephyr_version_of_a_relocated_elf(tmp_path: Path):
+    """A bare ELF outside its build tree has no version to report."""
+    elf = tmp_path / "zephyr.elf"
+    elf.write_bytes(b"")
+
+    assert compat.detect_zephyr_version(elf) is None
+
+
+def test_detect_zephyr_version_of_a_missing_path(tmp_path: Path):
+    assert compat.detect_zephyr_version(tmp_path / "nope" / "zephyr.elf") is None
+
+
+def test_mem_slab_resolves_the_sub_struct_layout():
+    """v3.7.0 and later keep the counters in a k_mem_slab_info sub-struct."""
+    elf = FakeElf(
+        {
+            ("k_mem_slab", "wait_q"): 0,
+            ("k_mem_slab", "info"): 16,
+            ("k_mem_slab_info", "num_blocks"): 0,
+            ("k_mem_slab_info", "block_size"): 4,
+            ("k_mem_slab_info", "num_used"): 8,
+        }
+    )
+
+    assert compat.resolve_fields(elf, compat.MEM_SLAB_FIELDS) == {
+        "mem_slab_wait_q": 0,
+        "mem_slab_num_blocks": 16,
+        "mem_slab_block_size": 20,
+        "mem_slab_num_used": 24,
+    }
+
+
+def test_mem_slab_falls_back_to_the_flat_layout():
+    """v3.0 and v3.3 carry the counters directly on k_mem_slab."""
+    elf = FakeElf(
+        {
+            ("k_mem_slab", "wait_q"): 0,
+            ("k_mem_slab", "num_blocks"): 16,
+            ("k_mem_slab", "block_size"): 20,
+            ("k_mem_slab", "num_used"): 24,
+        }
+    )
+
+    assert compat.resolve_fields(elf, compat.MEM_SLAB_FIELDS) == {
+        "mem_slab_wait_q": 0,
+        "mem_slab_num_blocks": 16,
+        "mem_slab_block_size": 20,
+        "mem_slab_num_used": 24,
+    }
+
+
+def test_usage_group_needs_the_kernel_wide_counter():
+    """z_kernel.usage only exists from v3.7.0, so older trees get no CPU stats."""
+    elf = FakeElf(
+        {
+            ("k_thread", "base"): 0,
+            ("_thread_base", "usage"): 48,
+            ("k_cycle_stats", "total"): 0,
+        }
+    )
+
+    assert compat.resolve_fields(elf, compat.USAGE_FIELDS) is None
+
+
+def test_heap_group_needs_max_allocated_bytes():
+    """z_heap.max_allocated_bytes arrived in v3.3.0; a v3.0 tree reports no heaps."""
+    elf = FakeElf(
+        {
+            ("z_heap", "free_bytes"): 16,
+            ("z_heap", "allocated_bytes"): 20,
+            ("z_heap", "end_chunk"): 8,
+        }
+    )
+
+    assert compat.resolve_fields(elf, compat.HEAP_FIELDS) is None
+
+
+def test_thread_entry_accepts_either_struct_spelling():
+    """Vendor trees have shipped __thread_entry and _thread_entry."""
+    double = FakeElf({("k_thread", "entry"): 112, ("__thread_entry", "pEntry"): 0})
+    single = FakeElf({("k_thread", "entry"): 112, ("_thread_entry", "pEntry"): 0})
+
+    for elf in (double, single):
+        assert compat.resolve_optional_fields(elf, compat.THREAD_META_FIELDS) == {
+            "thread_entry": 112
+        }
+
+
+def test_resolve_optional_fields_keeps_what_it_finds():
+    """Metadata members resolve independently of each other."""
+    elf = FakeElf({("k_thread", "base"): 0, ("_thread_base", "prio"): 14})
+
+    assert compat.resolve_optional_fields(elf, compat.THREAD_META_FIELDS) == {"thread_priority": 14}
+
+
+def test_resolve_optional_fields_of_nothing():
+    assert compat.resolve_optional_fields(FakeElf({}), compat.THREAD_META_FIELDS) == {}
+
+
+def test_kernel_object_registry_is_coherent():
+    """Every registered object names a struct and the fields needed to read it."""
+    assert set(compat.KERNEL_OBJECTS) == {
+        "semaphores",
+        "mutexes",
+        "msgqs",
+        "events",
+        "mem_slabs",
+        "work",
+    }
+
+    labels = [spec.label for spec in compat.KERNEL_OBJECTS.values()]
+    structs = [spec.struct for spec in compat.KERNEL_OBJECTS.values()]
+    assert len(set(labels)) == len(labels)
+    assert len(set(structs)) == len(structs)
+
+    for name, spec in compat.KERNEL_OBJECTS.items():
+        assert spec.fields, name
+        # Every field must offer at least one candidate path to resolve.
+        for field, candidates in spec.fields.items():
+            assert candidates, f"{name}.{field}"


### PR DESCRIPTION
ZView reads every offset from the ELF at runtime, so what breaks between Zephyr versions is not the version itself, but the field names and the Kconfig dependent layouts. This adds a `kernel/compat.py` where each field carries an ordered list of candidate paths, so a renamed member,
or one that moved into a sub-struct, is a single line to add.

The lookups that were spread over the orchestrator (`_try_resolve_*`) now go through those tables, and leaves one place to look if a tree stops resolving.

Coverage goes past what is wired today: the tables also carry `k_sem`, `k_mutex`, `k_msgq`, `k_event`, `k_mem_slab` and `k_work`, plus a small registry, so the walkers for those are additions rather than edits to this file. Kconfig now comes straight from the `CONFIG_*` symbols Zephyr leaves in the ELF instead of being guessed from struct sizes. The only visible difference is that a missing thread layout now says which Kconfig it needs instead of dropping a bare member error.

The tables were checked against the structs that actually shipped on `v3.0.0`, `v3.3.0`, `v3.7.0`, `v4.0.0` and `v4.4.0`.